### PR TITLE
Use pf2e flags to check for spell attacks and uuids to find actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2591,18 +2591,6 @@
                 "webpack": "^5.0.0"
             }
         },
-        "node_modules/css-loader/node_modules/nanoid": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
-            "dev": true,
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
         "node_modules/css-loader/node_modules/postcss": {
             "version": "8.4.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
@@ -6056,9 +6044,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.1.30",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-            "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -6095,15 +6083,23 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.6.6",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
             "dev": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
             "engines": {
                 "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/node-releases": {
@@ -13892,12 +13888,6 @@
                 "semver": "^7.3.5"
             },
             "dependencies": {
-                "nanoid": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-                    "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
-                    "dev": true
-                },
                 "postcss": {
                     "version": "8.4.6",
                     "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
@@ -16458,9 +16448,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.1.30",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-            "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true
         },
         "natural-compare": {
@@ -16491,9 +16481,9 @@
             }
         },
         "node-fetch": {
-            "version": "2.6.6",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
             "dev": true,
             "requires": {
                 "whatwg-url": "^5.0.0"

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -10,6 +10,7 @@ declare global {
             "xdy-pf2e-workbench.autoRollDamageForStrike": boolean;
             "xdy-pf2e-workbench.enableAutomaticMove": string;
             "xdy-pf2e-workbench.heroPointHandler": boolean;
+            "xdy-pf2e-workbench.notifyOnSpellCardNotFound": boolean;
             "xdy-pf2e-workbench.npcMystifier": boolean;
             "xdy-pf2e-workbench.npcMystifierAddRandomNumber": boolean;
             "xdy-pf2e-workbench.npcMystifierDemystifyAllTokensBasedOnTheSameActor": boolean;
@@ -247,6 +248,15 @@ export function registerSettings() {
         scope: "client",
         config: true,
         default: false,
+        type: Boolean,
+    });
+
+    game.settings.register(MODULENAME, "notifyOnSpellCardNotFound", {
+        name: `${MODULENAME}.SETTINGS.notifyOnSpellCardNotFound.name`,
+        hint: `${MODULENAME}.SETTINGS.notifyOnSpellCardNotFound.hint`,
+        scope: "client",
+        config: true,
+        default: true,
         type: Boolean,
     });
 

--- a/src/module/xdy-pf2e-workbench.ts
+++ b/src/module/xdy-pf2e-workbench.ts
@@ -71,41 +71,81 @@ function shouldIHandleThis(message: ChatMessage) {
 async function hooksForEveryone() {
     //Hooks for everyone
     if (game.settings.get(MODULENAME, "autoRollDamageForStrike")) {
-        Hooks.on("createChatMessage", (message: ChatMessage) => {
+        Hooks.on("createChatMessage", async (message: ChatMessage) => {
             const autorollDamageEnabled = game.settings.get(MODULENAME, "autoRollDamageForStrike");
             const messageActor: Actor = <Actor>game.actors?.get(<string>message.data.speaker.actor);
-            if (message.data.type === 5 && autorollDamageEnabled && messageActor && shouldIHandleThis(message)) {
-                const messageToken: TokenDocument = <TokenDocument>(
-                    canvas?.scene?.tokens.get(<string>message.data.speaker.token)
-                );
-                const strike = game.i18n.localize(`${MODULENAME}.SETTINGS.autoRollDamageForStrike.strike`);
-                const strikeName =
-                    message.data.flavor?.match(`<h4 class="action">${strike}: (.*?)<\\/h4>`) ||
-                    message.data.flavor?.match(`<strong>${strike}: (.*?)<\\/strong>`); //To support pf2e system before 3.5.0. BREAKING CHANGE to remove, so, do it whenever I do another breaking change
-                if (strikeName && strikeName[1]) {
-                    const degreeOfSuccess = message.data.flavor?.match(`(\\"success\\"|\\"criticalSuccess\\")`);
-                    if (degreeOfSuccess && degreeOfSuccess[0]) {
-                        // @ts-ignore
-                        const actions: any =
-                            // @ts-ignore Oof this is ugly. TODO Figure out how to do it properly.
-                            messageToken["data"]["document"]["_actor"]["data"]["data"]["actions"] ??
-                            // @ts-ignore
-                            messageActor?.data.data?.actions;
-                        const relevantStrike = actions
-                            .filter((a: { type: string }) => a.type === "strike")
-                            .find((action: { name: string }) => action.name === strikeName[1]);
-                        const rollOptions = messageActor
-                            // @ts-ignore
-                            ?.getRollOptions(["all", "damage-roll"]);
-                        if (degreeOfSuccess[0].includes("success")) {
-                            relevantStrike?.damage({
-                                options: rollOptions,
-                            });
-                        } else if (degreeOfSuccess[0].includes("criticalSuccess")) {
-                            relevantStrike?.critical({
-                                options: rollOptions,
+            const flags = message.data.flags.pf2e;
+            //@ts-ignore
+            const rollType = message.data.flags?.pf2e?.context?.type;
+            if (
+                rollType === "attack-roll" ||
+                (rollType === "spell-attack-roll" &&
+                    autorollDamageEnabled &&
+                    messageActor &&
+                    shouldIHandleThis(message))
+            ) {
+                //@ts-ignore
+                const actionId = flags?.origin?.uuid;
+                //@ts-ignore
+                const degreeOfSuccess = flags.context.outcome;
+                if (rollType === "spell-attack-roll") {
+                    if (degreeOfSuccess === "success" || degreeOfSuccess === "criticalSuccess") {
+                        const spell = await fromUuid(actionId);
+                        //@ts-ignore
+                        let spellLevel = spell.data.data.level;
+                        let levelFromChatCard = false;
+                        //@ts-ignore
+                        const chatLength = game.messages.contents.length;
+                        //check the last 5 messages for the spell info card. skips the last message which is the attach roll
+                        //most use cases shouldm't need to search further back than that
+                        for (let i = 1; i <= Math.min(6, chatLength); i++) {
+                            //@ts-ignore
+                            const m = game.messages.contents[chatLength - i];
+                            //@ts-ignore
+                            if (m.data.flags.pf2e.origin.uuid === actionId) {
+                                const re = m.data.content.match(/data-spell-lvl="(\d+)"/);
+                                if (re) {
+                                    levelFromChatCard = true;
+                                    spellLevel = re[1];
+                                    break;
+                                }
+                            }
+                        }
+                        if (
+                            !levelFromChatCard &&
+                            game.settings.get(MODULENAME, "notifyOnSpellCardNotFound") &&
+                            shouldIHandleThis(message)
+                        ) {
+                            //@ts-ignore
+                            ui.notifications.info(
+                                //@ts-ignore
+                                `The spell card could not be found. Casting ${spell.data.name} at minimum level for that spell.`
+                            );
+                        } else {
+                            //Until spell level flags are added to attack rolls it is the best I could come up with.
+                            //fakes the event.closest function that pf2e uses to parse spell level for heightening damage rolls.
+                            //@ts-ignore
+                            spell.rollDamage({
+                                currentTarget: {
+                                    closest: () => {
+                                        return { dataset: { spellLvl: Math.abs(spellLevel) } };
+                                    },
+                                },
                             });
                         }
+                    }
+                } else if (rollType === "attack-roll") {
+                    //@ts-ignore
+                    const rollOptions = messageActor?.getRollOptions(["all", "damage-roll"]);
+                    //@ts-ignore
+                    const actions = messageActor.data.data.actions;
+                    const action = actions
+                        .filter((a: { type: string }) => a.type === "strike")
+                        .find((a: { item: { id: any } }) => a.item.id === actionId);
+                    if (degreeOfSuccess === "success") {
+                        action?.damage({ options: rollOptions });
+                    } else if (degreeOfSuccess === "criticalSuccess") {
+                        action?.critical({ options: rollOptions });
                     }
                 }
             }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -31,6 +31,10 @@
         "result": "Result",
         "strike": "Strike"
       },
+      "notifyOnSpellCardNotFound": {
+        "hint": "Client setting to notify when a spell attack is rolled and no spell card was found.",
+        "name": "Client setting to notify when a spell attack is rolled and no spell card was found."
+      },
       "decreaseFrightenedConditionEachTurn": {
         "hint": "Client setting to automatically decrease the frightened condition each turn.",
         "name": "Client setting to automatically decrease the frightened condition each turn."


### PR DESCRIPTION
Feature: Auto roll spell strike damage and heighten spell strikes.

New behavious: Use pf2e flags instead of regex to check for strikes

Breaking changes: Should be compatible with pf2e 3.5 at least. Maybe older... I know 3.4 had the flags enabled, but I haven't been able to check compatability
