### PR TITLE
feat(settings): hide npc mystification settings into a button

### DIFF
--- a/src/module/settings/index.ts
+++ b/src/module/settings/index.ts
@@ -1,8 +1,8 @@
 // Keyboard key controlling whether the actor should be mystified, if this feature is toggled on
 
-import { MODULENAME } from "./xdy-pf2e-workbench";
-
-export let mystifyModifierKey: string;
+import { MODULENAME } from "../xdy-pf2e-workbench";
+import { MystificationSettings } from "./mystification";
+export { mystifyModifierKey } from "./mystification";
 
 function debouncedReload() {
     foundry.utils.debounce(() => {
@@ -12,6 +12,8 @@ function debouncedReload() {
 
 export function registerSettings() {
     console.log(`${MODULENAME} | registerSettings`);
+
+    MystificationSettings.registerSettingsAndCreateMenu();
 
     game.settings.register(MODULENAME, "maxHeroPoints", {
         name: `${MODULENAME}.SETTINGS.maxHeroPoints.name`,
@@ -160,191 +162,6 @@ export function registerSettings() {
             reaching0HP: game.i18n.localize(`${MODULENAME}.SETTINGS.enableAutomaticMove.reaching0HP`),
         },
         onChange: () => debouncedReload(),
-    });
-
-    game.settings.register(MODULENAME, "npcMystifier", {
-        name: `${MODULENAME}.SETTINGS.npcMystifier.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifier.hint`,
-        scope: "world",
-        config: true,
-        default: true,
-        type: Boolean,
-        onChange: () => debouncedReload(),
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierMethod", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierMethod.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierMethod.hint`,
-        scope: "world",
-        config: true,
-        default: "traits",
-        type: String,
-        choices: {
-            traits: `${MODULENAME}.SETTINGS.npcMystifierMethod.traits`,
-        },
-    });
-
-    //These apply to all mystification methods, I think
-    game.settings.register(MODULENAME, "npcMystifierPrefix", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierPrefix.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierPrefix.hint`,
-        scope: "world",
-        config: true,
-        type: String,
-        default: "",
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierPostfix", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierPostfix.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierPostfix.hint`,
-        scope: "world",
-        config: true,
-        type: String,
-        default: "",
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierDemystifyAllTokensBasedOnTheSameActor", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierDemystifyAllTokensBasedOnTheSameActor.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierDemystifyAllTokensBasedOnTheSameActor.hint`,
-        scope: "world",
-        config: true,
-        default: false,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierModifierKey", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierModifierKey.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierModifierKey.hint`,
-        scope: "world",
-        config: true,
-        type: String,
-        choices: {
-            ALWAYS: "Always",
-            DISABLED: "Disabled",
-            ALT: "Alt",
-            CONTROL: "Ctrl",
-        },
-        default: "CONTROL",
-        onChange: (key) => {
-            mystifyModifierKey = <string>key;
-        },
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierAddRandomNumber", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierAddRandomNumber.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierAddRandomNumber.hint`,
-        scope: "world",
-        config: true,
-        default: true,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierSkipRandomNumberForUnique", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierSkipRandomNumberForUnique.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierSkipRandomNumberForUnique.hint`,
-        scope: "world",
-        config: true,
-        default: false,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierKeepNumberAtEndOfName", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierKeepNumberAtEndOfName.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierKeepNumberAtEndOfName.hint`,
-        scope: "world",
-        config: true,
-        default: true,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierUseSize", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierUseSize.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierUseSize.hint`,
-        scope: "world",
-        config: true,
-        default: false,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierFilterRarities", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierFilterRarities.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierFilterRarities.hint`,
-        scope: "world",
-        config: true,
-        default: true,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierFilterRaritiesReplacement", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierFilterRaritiesReplacement.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierFilterRaritiesReplacement.hint`,
-        scope: "world",
-        config: true,
-        default: "",
-        type: String,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierFilterEliteWeak", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierFilterEliteWeak.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierFilterEliteWeak.hint`,
-        scope: "world",
-        config: true,
-        default: false,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierFilterCreatureTypesTraits", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierFilterCreatureTypesTraits.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierFilterCreatureTypesTraits.hint`,
-        scope: "world",
-        config: true,
-        default: false,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierFilterCreatureFamilyTraits", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierFilterCreatureFamilyTraits.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierFilterCreatureFamilyTraits.hint`,
-        scope: "world",
-        config: true,
-        default: false,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierFilterAlignmentTraits", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierFilterAlignmentTraits.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierFilterAlignmentTraits.hint`,
-        scope: "world",
-        config: true,
-        default: true,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierFilterOtherTraits", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierFilterOtherTraits.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierFilterOtherTraits.hint`,
-        scope: "world",
-        config: true,
-        default: false,
-        type: Boolean,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierFilterBlacklist", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierFilterBlacklist.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierFilterBlacklist.hint`,
-        scope: "world",
-        config: true,
-        default: "",
-        type: String,
-    });
-
-    game.settings.register(MODULENAME, "npcMystifierUseMystifiedNameInChat", {
-        name: `${MODULENAME}.SETTINGS.npcMystifierUseMystifiedNameInChat.name`,
-        hint: `${MODULENAME}.SETTINGS.npcMystifierUseMystifiedNameInChat.hint`,
-        scope: "world",
-        config: true,
-        default: false,
-        type: Boolean,
     });
 
     game.settings.register(MODULENAME, "automatedAnimationOn", {
@@ -740,6 +557,4 @@ export function registerSettings() {
         type: Boolean,
         onChange: () => debouncedReload(),
     });
-
-    mystifyModifierKey = <string>game.settings.get(MODULENAME, "npcMystifierModifierKey");
 }

--- a/src/module/settings/menu.ts
+++ b/src/module/settings/menu.ts
@@ -1,0 +1,87 @@
+import { MODULENAME } from "../xdy-pf2e-workbench";
+
+export type PartialSettingsData = Omit<SettingRegistration, "scope" | "config">;
+
+interface SettingsTemplateData extends PartialSettingsData {
+    key: string;
+    value: unknown;
+}
+
+export interface MenuTemplateData extends FormApplicationData {
+    settings: SettingsTemplateData[];
+}
+
+/** An adjusted copy of the settings menu from core pf2e meant for the module */
+export class SettingsMenuPF2e extends FormApplication {
+    static readonly namespace: string;
+
+    static override get defaultOptions() {
+        const options = super.defaultOptions;
+        options.classes.push("settings-menu");
+
+        return mergeObject(options, {
+            title: `${MODULENAME}.SETTINGS.${this.namespace}.name`,
+            id: `${this.namespace}-settings`,
+            template: `modules/xdy-pf2e-workbench/templates/menu.html`,
+            width: 550,
+            height: "auto",
+            closeOnSubmit: true,
+        });
+    }
+
+    get namespace(): string {
+        return (this.constructor as typeof SettingsMenuPF2e).namespace;
+    }
+
+    /** Settings to be registered and also later referenced during user updates */
+    protected static get settings(): Record<string, PartialSettingsData> {
+        return {};
+    }
+
+    static registerSettings(): void {
+        const settings = this.settings;
+        for (const setting of Object.keys(settings)) {
+            game.settings.register(MODULENAME, setting, {
+                ...settings[setting],
+                config: false,
+            });
+        }
+    }
+
+    static registerSettingsAndCreateMenu() {
+        game.settings.registerMenu(MODULENAME, this.namespace, {
+            name: `${MODULENAME}.SETTINGS.${this.namespace}.name`,
+            label: `${MODULENAME}.SETTINGS.${this.namespace}.label`,
+            hint: `${MODULENAME}.SETTINGS.${this.namespace}.hint`,
+            icon: "fas fa-robot",
+            type: this,
+            restricted: true,
+        });
+        this.registerSettings();
+    }
+
+    override getData(): MenuTemplateData {
+        const settings = (this.constructor as typeof SettingsMenuPF2e).settings;
+        const templateData: SettingsTemplateData[] = Object.entries(settings).map(([key, setting]) => {
+            const value = game.settings.get(MODULENAME, key);
+            return {
+                ...setting,
+                key,
+                value,
+                isSelect: !!setting.choices,
+                isCheckbox: setting.type === Boolean,
+            };
+        });
+        return mergeObject(super.getData(), {
+            settings: templateData,
+            instructions: `${MODULENAME}.SETTINGS.${this.namespace}.hint`,
+        });
+    }
+
+    protected override async _updateObject(_event: Event, data: Record<string, unknown>): Promise<void> {
+        const settings = (this.constructor as typeof SettingsMenuPF2e).settings;
+        for (const key of Object.keys(settings)) {
+            await game.settings.set(MODULENAME, key, data[key]);
+        }
+    }
+}

--- a/src/module/settings/mystification.ts
+++ b/src/module/settings/mystification.ts
@@ -1,0 +1,170 @@
+import { MODULENAME } from "../xdy-pf2e-workbench";
+import { SettingsMenuPF2e } from "./menu";
+
+function debouncedReload() {
+    foundry.utils.debounce(() => {
+        window.location.reload();
+    }, 100);
+}
+
+export let mystifyModifierKey: string;
+
+export class MystificationSettings extends SettingsMenuPF2e {
+    static override namespace = "mystificationSettings";
+
+    protected static override get settings(): Record<string, SettingRegistration> {
+        return {
+            npcMystifier: {
+                name: `${MODULENAME}.SETTINGS.npcMystifier.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifier.hint`,
+                scope: "world",
+                default: true,
+                type: Boolean,
+                onChange: () => debouncedReload(),
+            },
+            npcMystifierMethod: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierMethod.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierMethod.hint`,
+                scope: "world",
+                default: "traits",
+                type: String,
+                choices: {
+                    traits: `${MODULENAME}.SETTINGS.npcMystifierMethod.traits`,
+                },
+            },
+            npcMystifierPrefix: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierPrefix.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierPrefix.hint`,
+                scope: "world",
+                type: String,
+                default: "",
+            },
+            npcMystifierPostfix: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierPostfix.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierPostfix.hint`,
+                scope: "world",
+                type: String,
+                default: "",
+            },
+            npcMystifierDemystifyAllTokensBasedOnTheSameActor: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierDemystifyAllTokensBasedOnTheSameActor.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierDemystifyAllTokensBasedOnTheSameActor.hint`,
+                scope: "world",
+                default: false,
+                type: Boolean,
+            },
+            npcMystifierModifierKey: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierModifierKey.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierModifierKey.hint`,
+                scope: "world",
+                type: String,
+                choices: {
+                    ALWAYS: "Always",
+                    DISABLED: "Disabled",
+                    ALT: "Alt",
+                    CONTROL: "Ctrl",
+                },
+                default: "CONTROL",
+                onChange: (key) => {
+                    mystifyModifierKey = <string>key;
+                },
+            },
+            npcMystifierAddRandomNumber: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierAddRandomNumber.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierAddRandomNumber.hint`,
+                scope: "world",
+                default: true,
+                type: Boolean,
+            },
+            npcMystifierSkipRandomNumberForUnique: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierSkipRandomNumberForUnique.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierSkipRandomNumberForUnique.hint`,
+                scope: "world",
+                default: false,
+                type: Boolean,
+            },
+            npcMystifierKeepNumberAtEndOfName: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierKeepNumberAtEndOfName.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierKeepNumberAtEndOfName.hint`,
+                scope: "world",
+                default: true,
+                type: Boolean,
+            },
+            npcMystifierUseSize: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierUseSize.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierUseSize.hint`,
+                scope: "world",
+                default: false,
+                type: Boolean,
+            },
+            npcMystifierFilterRarities: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierFilterRarities.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierFilterRarities.hint`,
+                scope: "world",
+                default: true,
+                type: Boolean,
+            },
+            npcMystifierFilterRaritiesReplacement: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierFilterRaritiesReplacement.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierFilterRaritiesReplacement.hint`,
+                scope: "world",
+                default: "",
+                type: String,
+            },
+            npcMystifierFilterEliteWeak: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierFilterEliteWeak.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierFilterEliteWeak.hint`,
+                scope: "world",
+                default: false,
+                type: Boolean,
+            },
+            npcMystifierFilterCreatureTypesTraits: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierFilterCreatureTypesTraits.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierFilterCreatureTypesTraits.hint`,
+                scope: "world",
+                default: false,
+                type: Boolean,
+            },
+            npcMystifierFilterCreatureFamilyTraits: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierFilterCreatureFamilyTraits.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierFilterCreatureFamilyTraits.hint`,
+                scope: "world",
+                default: false,
+                type: Boolean,
+            },
+            npcMystifierFilterAlignmentTraits: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierFilterAlignmentTraits.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierFilterAlignmentTraits.hint`,
+                scope: "world",
+                default: true,
+                type: Boolean,
+            },
+            npcMystifierFilterOtherTraits: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierFilterOtherTraits.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierFilterOtherTraits.hint`,
+                scope: "world",
+                default: false,
+                type: Boolean,
+            },
+            npcMystifierFilterBlacklist: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierFilterBlacklist.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierFilterBlacklist.hint`,
+                scope: "world",
+                default: "",
+                type: String,
+            },
+            npcMystifierUseMystifiedNameInChat: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierUseMystifiedNameInChat.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierUseMystifiedNameInChat.hint`,
+                scope: "world",
+                default: false,
+                type: Boolean,
+            }
+        };
+    }
+
+    static override registerSettings(): void {
+        super.registerSettings();
+        mystifyModifierKey = <string>game.settings.get(MODULENAME, "npcMystifierModifierKey");
+    }
+}

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -8,6 +8,11 @@
       "deliberateDeathUsed": "Deliberate Death Used"
     },
     "SETTINGS": {
+      "mystificationSettings": {
+        "hint": "Enable and configure NPC mystification",
+        "name": "NPC Mystification",
+        "label": "Manage NPC Mystification Settings"
+      },
       "abpVariantAllowItemBonuses": {
         "hint": "World setting to not disable item bonuses when using ABP.",
         "name": "(World) Do not disable item bonuses when using ABP."

--- a/static/templates/menu.html
+++ b/static/templates/menu.html
@@ -1,0 +1,31 @@
+<form autocomplete="off" onsubmit="event.preventDefault();">
+    <p class="instructions">{{localize instructions}}</p>
+    {{#each settings as |setting|}}
+        <!-- {{setting.key}} -->
+        <div class="form-group">
+            <label for="{{setting.key}}">{{localize setting.name}}</label>
+            <div class="form-fields">
+                {{#if setting.isSelect}}
+                    <select name="{{setting.key}}">
+                        {{#select setting.value}}
+                            {{#each setting.choices as |label value|}}
+                                <option value="{{value}}">{{localize label}}</option>
+                            {{/each}}
+                        {{/select}}
+                    </select>
+                {{else if setting.isCheckbox}}
+                    <input type="checkbox" name="{{setting.key}}" {{checked setting.value}} />
+                {{/if}}
+            </div>
+            <p class="notes">{{localize setting.hint}}</p>
+        </div>
+    {{/each}}
+    <div class="form-group buttons">
+        <button type="submit" name="submit">
+            <i class="far fa-save"></i> {{localize "SETTINGS.Save"}}
+        </button>
+        <button type="reset" name="reset">
+            <i class="fas fa-undo"></i> {{localize "PF2E.SETTINGS.ResetChanges"}}
+        </button>
+    </div>
+</form>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [ X ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ? ] Docs have been added / updated (for bug fixes / features)

* **What is the current behavior?** (You can also link to an open issue here)
#163

* **What is the new behavior (if this is a feature change)?**
Hide NPC mystification settings under a new menu.
![image](https://user-images.githubusercontent.com/1286721/178129236-8759929e-fe9e-4115-a9d6-39a49384ec01.png)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
The settings should be the same, any that don't properly transfer is a typo and therefore a bug.

* **Other information**:
Stole this from core's implementation of the same thing, but adjusted for your module (so for example, settings aren't nested into namespace.setting