### PR TITLE
feat: Persistent adjective from rolltable

### DIFF
--- a/src/module/settings/index.ts
+++ b/src/module/settings/index.ts
@@ -5,7 +5,7 @@ import { WorkbenchWorldAutomationSettings } from "./automation-world";
 import { WorkbenchClientAutomationSettings } from "./automation-client";
 import { WorkbenchQolWorldSettings } from "./qol-world";
 
-export { mystifyModifierKey } from "./mystification";
+export { mystifyModifierKey, mystifyRandomPropertyType } from "./mystification";
 
 export function debouncedReload() {
     foundry.utils.debounce(() => {

--- a/src/module/settings/mystification.ts
+++ b/src/module/settings/mystification.ts
@@ -2,6 +2,7 @@ import { MODULENAME } from "../xdy-pf2e-workbench";
 import { debouncedReload } from "./index";
 import { SettingsMenuPF2eWorkbench } from "./menu";
 
+export let mystifyRandomPropertyType: string;
 export let mystifyModifierKey: string;
 
 export class WorkbenchMystificationSettings extends SettingsMenuPF2eWorkbench {
@@ -23,6 +24,20 @@ export class WorkbenchMystificationSettings extends SettingsMenuPF2eWorkbench {
                 scope: "world",
                 default: true,
                 type: Boolean,
+            },
+            npcMystifierPrefix: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierPrefix.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierPrefix.hint`,
+                scope: "world",
+                type: String,
+                default: "",
+            },
+            npcMystifierPostfix: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierPostfix.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierPostfix.hint`,
+                scope: "world",
+                type: String,
+                default: "",
             },
             npcMystifierUseSize: {
                 name: `${MODULENAME}.SETTINGS.npcMystifierUseSize.name`,
@@ -101,40 +116,41 @@ export class WorkbenchMystificationSettings extends SettingsMenuPF2eWorkbench {
                     }
                 },
             },
-            npcMystifierAddRandomNumber: {
-                name: `${MODULENAME}.SETTINGS.npcMystifierAddRandomNumber.name`,
-                hint: `${MODULENAME}.SETTINGS.npcMystifierAddRandomNumber.hint`,
-                scope: "world",
-                default: true,
-                type: Boolean,
-            },
-            npcMystifierSkipRandomNumberForUnique: {
-                name: `${MODULENAME}.SETTINGS.npcMystifierSkipRandomNumberForUnique.name`,
-                hint: `${MODULENAME}.SETTINGS.npcMystifierSkipRandomNumberForUnique.hint`,
-                scope: "world",
-                default: true,
-                type: Boolean,
-            },
-            npcMystifierKeepNumberAtEndOfName: {
-                name: `${MODULENAME}.SETTINGS.npcMystifierKeepNumberAtEndOfName.name`,
-                hint: `${MODULENAME}.SETTINGS.npcMystifierKeepNumberAtEndOfName.hint`,
-                scope: "world",
-                default: true,
-                type: Boolean,
-            },
-            npcMystifierPrefix: {
-                name: `${MODULENAME}.SETTINGS.npcMystifierPrefix.name`,
-                hint: `${MODULENAME}.SETTINGS.npcMystifierPrefix.hint`,
+            npcMystifierAddRandomProperty: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierAddRandomProperty.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierAddRandomProperty.hint`,
                 scope: "world",
                 type: String,
-                default: "",
+                choices: {
+                    NONE: "None",
+                    NUMBER: "Number",
+                    ADJECTIVE: "Adjective",
+                },
+                default: "NONE",
+                onChange: (key) => {
+                    mystifyRandomPropertyType = <string>key;
+                },
             },
-            npcMystifierPostfix: {
-                name: `${MODULENAME}.SETTINGS.npcMystifierPostfix.name`,
-                hint: `${MODULENAME}.SETTINGS.npcMystifierPostfix.hint`,
+            npcMystifierRandomAdjectiveRollTable: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierAdjective.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierAdjective.hint`,
                 scope: "world",
-                type: String,
                 default: "",
+                type: String,
+            },
+            npcMystifierKeepRandomProperty: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierKeepRandomProperty.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierKeepRandomProperty.hint`,
+                scope: "world",
+                default: true,
+                type: Boolean,
+            },
+            npcMystifierSkipRandomPropertyForUnique: {
+                name: `${MODULENAME}.SETTINGS.npcMystifierSkipRandomPropertyForUnique.name`,
+                hint: `${MODULENAME}.SETTINGS.npcMystifierSkipRandomPropertyForUnique.hint`,
+                scope: "world",
+                default: true,
+                type: Boolean,
             },
             npcMystifierModifierKey: {
                 name: `${MODULENAME}.SETTINGS.npcMystifierModifierKey.name`,
@@ -165,5 +181,6 @@ export class WorkbenchMystificationSettings extends SettingsMenuPF2eWorkbench {
     static override registerSettings(): void {
         super.registerSettings();
         mystifyModifierKey = <string>game.settings.get(MODULENAME, "npcMystifierModifierKey");
+        mystifyRandomPropertyType = <string>game.settings.get(MODULENAME, "npcMystifierAddRandomProperty");
     }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -262,9 +262,9 @@
         "hint": "Check to enable npc mystifier, renaming tokens on the active scene based on their traits if Ctrl (configurable) is clicked when adding to scene. Save settings to show/hide additional options.",
         "name": "Enable npc mystifier."
       },
-      "npcMystifierAddRandomNumber": {
-        "hint": "Check to add a random number when mystifying npcs.",
-        "name": "Add random number to name"
+      "npcMystifierAddRandomProperty": {
+        "hint": "Select a type of random property when mystifying npcs.",
+        "name": "Add random property of chosen type to name"
       },
       "npcMystifierDemystifyAllTokensBasedOnTheSameActor": {
         "hint": "Check to make all mystification act on all tokens based on the same actor.",
@@ -306,9 +306,9 @@
         "hint": "Enter word to replace rarities greater than Common with (e.g. 'Unusual') in this text field. If empty, do not change the displayed rarity.",
         "name": "Replace rarities rarer than Common"
       },
-      "npcMystifierKeepNumberAtEndOfName": {
-        "hint": "Check to keep token number *in the same format as those added by this module* at end of name (if any) when mystifying/demystifying npcs.",
-        "name": "Keep token number when mystifying/demystifying."
+      "npcMystifierKeepRandomProperty": {
+        "hint": "Check to keep token property *in the same format as those added by this module* at end of name (if any) when mystifying/demystifying npcs.",
+        "name": "Keep token property when mystifying/demystifying."
       },
       "npcMystifierModifierKey": {
         "hint": "Select to enable setting which key to hold to mystify creature as it's dragged out to the active scene. Note that if you choose Alt (not the default) it also hides the npc.",
@@ -326,9 +326,13 @@
         "hint": "Add text to prefix new name with, defaults to '' (example: 'Unknown'), if this matches the name of a rollable table a random text result from this table will be used as the prefix instead.",
         "name": "Word or rollable table prefix"
       },
-      "npcMystifierSkipRandomNumberForUnique": {
-        "hint": "Check to skip adding a random number when mystifying unique npcs.",
-        "name": "Skip random number for unique npcs."
+      "npcMystifierSkipRandomPropertyForUnique": {
+        "hint": "Check to skip adding a random property when mystifying unique npcs.",
+        "name": "Skip random property for unique npcs."
+      },
+      "npcMystifierAdjective": {
+        "hint": "Adds a word from the rolltable as a prefix (Random property needs to be set to 'Adjective').",
+        "name": "Rolltable adjective"
       },
       "npcMystifierUseMystifiedNameInChat": {
         "hint": "(Experimental) Check to use mystified name inside chat messages by replacing the actor name with the mystified name.",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -130,7 +130,7 @@
         "hint": "Activer la mystification des PNJ en renommant les jetons sur la scène active en fonction de leurs traits si vous appuyez sur Ctrl (configurable) lorsque vous ajoutez la scène. Sauvegardez pour montrer/cacher les options supplémentaires.",
         "name": "Activer la mystification des PNJ."
       },
-      "npcMystifierAddRandomNumber": {
+      "npcMystifierAddRandomProperty": {
         "hint": "Cliquez pour ajouter un nombre aléatoire lorsque vous mystifiez les PNJ.",
         "name": "Ajouter un nombre aléatoire au nom"
       },
@@ -170,9 +170,9 @@
         "hint": "Définir le mot pour remplacer les raretés supérieures à courante (ex. 'Inhabituelle') dans ce champ textuel. Si c'est vide, cela ne change pas la rareté affichée.",
         "name": "Remplacer les raretés supérieures à Courant"
       },
-      "npcMystifierKeepNumberAtEndOfName": {
-        "hint": "Cliquez pour conserver le numéro du jeton *dans le même format que celui ajouté par ce module* à la fin du nom (s'il y en a) lorsque vous mystifiez/démystifiez les PNJ.",
-        "name": "Garder le nombre du jeton lorsque vous mystifiez/démystifiez."
+      "npcMystifierKeepRandomProperty": {
+        "hint": "Cliquez pour conserver le propriété du jeton *dans le même format que celui ajouté par ce module* à la fin du nom (s'il y en a) lorsque vous mystifiez/démystifiez les PNJ.",
+        "name": "Garder le propriété du jeton lorsque vous mystifiez/démystifiez."
       },
       "npcMystifierModifierKey": {
         "hint": "Choisissez d'activer le choix de la touche à maintenir pressée pour mystifier la créature lorsqu'elle est glissée sur la scène active. Notez que si vous choisissez Alt (pas par défaut) cela cache aussi le PNJ.",
@@ -190,9 +190,13 @@
         "hint": "Ajouter le préfixe du nouveau nom avec, par défaut '' (exemple : 'Inconnu'), si cela correspond au nom d'une table aléatoire, un texte aléatoire provenant de cette table sera utilisé comme préfixe à la place.",
         "name": "Mot ou table aléatoire préfixe"
       },
-      "npcMystifierSkipRandomNumberForUnique": {
-        "hint": "Cliquez pour éviter d'accoler un numéro aléatoire lorsque vous mystifiez des PNJ uniques.",
-        "name": "Éviter le numéro aléatoire pour les PNJ uniques."
+      "npcMystifierSkipRandomPropertyForUnique": {
+        "hint": "Cliquez pour éviter d'accoler un propriété aléatoire lorsque vous mystifiez des PNJ uniques.",
+        "name": "Éviter le propriété aléatoire pour les PNJ uniques."
+      },
+      "npcMystifierAdjective": {
+        "hint": "Adds a word from the rolltable as a prefix (Random property needs to be set to 'Adjective').",
+        "name": "Rollable table prefix"
       },
       "npcMystifierUseMystifiedNameInChat": {
         "hint": "(Expérimental) Cliquez pour utiliser le nom mystifié à l'intérieur des messages de la conversation en remplaçant le nom de l'acteur par le nom mystifié.",

--- a/static/lang/pt_BR.json
+++ b/static/lang/pt_BR.json
@@ -106,9 +106,13 @@
         "hint": "Adiciona um prefixo ao novo nome. Se corresponder ao nome de uma tabela de rolagem, um resultado aleatório será usado como prefixo.",
         "name": "Prefixo: Palavra ou Tabela de Rolagem"
       },
-      "npcMystifierSkipRandomNumberForUnique": {
-        "name": "Não adicionar números a PdMs únicos",
-        "hint": "Não adiciona números aleatórios quando mistificar PdMs únicos."
+      "npcMystifierSkipRandomPropertyForUnique": {
+        "name": "Não adicionar propriedade a PdMs únicos",
+        "hint": "Não adiciona propriedade aleatórios quando mistificar PdMs únicos."
+      },
+      "npcMystifierAdjective": {
+        "hint": "Adds a word from the rolltable as a prefix (Random property needs to be set to 'Adjective').",
+        "name": "Rollable table prefix"
       },
       "npcMystifierUseMystifiedNameInChat": {
         "name": "(Experimental) Mistificar nome em mensagens de chat",
@@ -138,15 +142,15 @@
         "hint": "Defina uma palavra para substituir raridades maiores que Comum. Caso fique vazio, não mudará a raridade exibida.",
         "name": "Substituir raridades maiores que Comum"
       },
-      "npcMystifierKeepNumberAtEndOfName": {
-        "name": "Manter numeração de token",
-        "hint": "Mantém a numeração de tokens (no mesmo formato como adicionado por este módulo) no fim do nome quando mistificar PdMs."
+      "npcMystifierKeepRandomProperty": {
+        "name": "Manter propriedade de token",
+        "hint": "Mantém a propriedade de tokens (no mesmo formato como adicionado por este módulo) no fim do nome quando mistificar PdMs."
       },
       "npcMystifier": {
         "hint": "Habilita o Mistificador de PdMs, renomeando tokens em cenas ativas baseado em seus traços se Ctrl (configurável) estiver pressionado ao adicioná-los à cena. Altere esta configuração para mostrar ou esconder opções adicionais.",
         "name": "Habilitar Mistificador de PdMs"
       },
-      "npcMystifierAddRandomNumber": {
+      "npcMystifierAddRandomProperty": {
         "hint": "Adiciona número aleatórios quando mistificar.",
         "name": "Adicionar números aleatórios ao nome"
       },

--- a/static/lang/sv.json
+++ b/static/lang/sv.json
@@ -62,9 +62,9 @@
         "hint": "Slå på npcmystifierare, byt namn på spelfigur på den aktiva scenen baserat på deras egenskaper om Ctrl (konfigurerbar) klickas när du lägger till spelfiguren scenen.",
         "name": "Slå på npcmystifierare."
       },
-      "npcMystifierAddRandomNumber": {
-        "hint": "Aktiverar att lägga till ett slumpmässigt nummer när man mystifierar npcs. Observera att om spelfigur eller karaktär redan har ett nummer som suffix kommer detta inte att fungera bra.",
-        "name": "Lägg till slumpmässigt nummer i namnet"
+      "npcMystifierAddRandomProperty": {
+        "hint": "Aktiverar att lägga till ett slumpmässigt fastighet när man mystifierar npcs. Observera att om spelfigur eller karaktär redan har ett nummer som suffix kommer detta inte att fungera bra.",
+        "name": "Lägg till slumpmässigt fastighet i namnet"
       },
       "npcMystifierDemystifyAllTokensBasedOnTheSameActor": {
         "hint": "Aktiverar att alla spelfigurer på den aktiva scenen som är baserade på samma varelse som den som avmystifieras också avmystifieras.",
@@ -102,7 +102,7 @@
         "hint": "Ersätter sällsyntheter ovanligare än Common med (t.ex. 'Ovanlig'). Om det är tomt, ändra inte den visade sällsyntheten.",
         "name": "Ord att ersätta sällsyntheter större än Vanlig med"
       },
-      "npcMystifierKeepNumberAtEndOfName": {
+      "npcMystifierKeepRandomProperty": {
         "hint": "Behåll spelfigurnummer *i samma format som dom som läggs till av denna modul* i slutet av namnet (om något) när du mystifierar/avmystifierar npcs.",
         "name": "Behåll spelfigurnummer när du mystifierar/avmystifierar."
       },
@@ -122,9 +122,13 @@
         "hint": "Vad ska det nya namnet prefixas med, default '' (exempel: 'Okänd'), om det är namnet på en slumptabell så används en textrad från den tabellen som prefix .",
         "name": "Ord eller slumptabell att prefixa nytt namn med"
       },
-      "npcMystifierSkipRandomNumberForUnique": {
-        "hint": "Låter bli att lägga till slumpmässigt nummer för unika npcs.",
-        "name": "Inget slumpmässigt nummer för unika npcs."
+      "npcMystifierSkipRandomPropertyForUnique": {
+        "hint": "Låter bli att lägga till slumpmässigt fastighet för unika npcs.",
+        "name": "Inget slumpmässigt fastighet för unika npcs."
+      },
+      "npcMystifierAdjective": {
+        "hint": "Adds a word from the rolltable as a prefix (Random property needs to be set to 'Adjective').",
+        "name": "Rollable table prefix"
       },
       "npcMystifierUseMystifiedNameInChat": {
         "hint": "(Experimentellt) Använd mystifierat namn i chattmeddelanden genom att ersätta karaktärns namn med det mystifierade namnet. Kommer utan tvekan att se riktigt dåligt ut på vissa förmågor.",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
You can only set a random number as a persistent 'uniquefyer'
![grafik](https://user-images.githubusercontent.com/6615662/196052715-64f06ae0-da3b-4e5b-8fb5-d5025c49b56f.png)


* **What is the new behavior (if this is a feature change)?**
Random number is now "Random Property" which can be either a number a an adjective from a roll table. (for testing i used the one from token mold: https://github.com/Moerill/token-mold/blob/master/assets/adjectives.db)
Detecting the adjective is like the number before very heuristic.
![grafik](https://user-images.githubusercontent.com/6615662/196052677-b762578e-1d02-43e4-bc8a-8d7309a04ca0.png)



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
The setting to set random number as suffix changed to a dropdown with multiple option. I did set the default to 'None' although the old default was 'true' which would reflect to 'Number'.


* **Other information**:
This is my first time with nodeJS so maybe have a thorough review :P Technically this is ready tho.