### PR TITLE
fix: Fix skill action slugs not being added along to rolls

### DIFF
--- a/src/module/feature/skill-actions/skill-actions.ts
+++ b/src/module/feature/skill-actions/skill-actions.ts
@@ -141,7 +141,7 @@ export class SkillAction {
                             event,
                             modifiers: variant.modifiers,
                             // @ts-ignore
-                            options: [`action:${this.slug}`],
+                            options: [`action:${this.data.slug}`],
                         })
                         .then()
                 );


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fixes the issue where a roll generated from a skill action that has no matching system macro (like Escape) would fill the roll with an `action:undefined` option.

* **What is the current behavior?** (You can also link to an open issue here)

Any such action will not have rule elements that _should_ apply to it apply to it.    
For example:

1. Create a player character, add the Flexible Catfolk heritage to it.
2. Using the skill action button on the sheet added by the Workbench, roll an Escape check using either Acrobatics or Athletics.
3. The +1 circumstance FlatModifier will appear on the roll window, but will be disabled.
4. If rolled, inspecting the roll will reveal that there are no `action:escape` options in the roll, only an `action:undefined` instead.

The code tries to grab the slug from `this.slug`, but it actually exists in `this.data.slug`.

* **What is the new behavior (if this is a feature change)?**

The aforementioned example will now look as such:

3. The +1 circumstance FlatModifier will appear on the roll window, and will be enabled.
4. If rolled, inspecting the roll will reveal that there is an `action:escape` option in the roll.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

Nope.

* **Other information**:

This does not fully fix the issue -- Recall Knowledge will still have a problem related to slugs. I will be making an issue for that, as that might need a bigger rework.