### PR TITLE
Adds a setting to show the actions description in chat

### DIFF
--- a/src/module/feature/skill-actions/skill-actions.ts
+++ b/src/module/feature/skill-actions/skill-actions.ts
@@ -134,17 +134,16 @@ export class SkillAction {
                         .then();
                 }
             } else {
-                this.toChat().then(
-                    variant.skill
+                if (game.settings.get(MODULENAME, "skillActionsDescription")) await this.toChat();
+                variant.skill
+                    // @ts-ignore
+                    .roll({
+                        event,
+                        modifiers: variant.modifiers,
                         // @ts-ignore
-                        .roll({
-                            event,
-                            modifiers: variant.modifiers,
-                            // @ts-ignore
-                            options: [`action:${this.data.slug}`],
-                        })
-                        .then()
-                );
+                        options: [`action:${this.data.slug}`],
+                    })
+                    .then();
             }
         }
     }

--- a/src/module/settings/index.ts
+++ b/src/module/settings/index.ts
@@ -87,6 +87,15 @@ export function registerWorkbenchSettings() {
         },
     });
 
+    game.settings.register(MODULENAME, "skillActionsDescription", {
+        name: `${MODULENAME}.skillActions.Settings.Description.name`,
+        hint: `${MODULENAME}.skillActions.Settings.Description.hint`,
+        scope: "client",
+        config: true,
+        default: false,
+        type: Boolean,
+    });
+
     // game.settings.register(MODULENAME, "skillActionsHideDuplicates", {
     //     name: `${MODULENAME}.skillActionsHideDuplicates.Settings.hideDuplicates.name`,
     //     hint: `${MODULENAME}.skillActionsHideDuplicates.Settings.hideDuplicates.hint`,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -39,6 +39,10 @@
           "hint": "Icon style on the skill; Action Cost Icon: For the actions cost icon, Skill Icon: For the skills icon if it's available",
           "actionCostIcon": "Action Cost Icon",
           "skillIcon": "Skill Icon"
+        },
+        "Description": {
+          "name": "Skill Actions Description",
+          "hint": "Wheter to show the actions description in the chat when rolling"
         }
       },
       "UnequipAll": {


### PR DESCRIPTION
This PR will add a new setting `skillActionsDescription` which will enable/disable sending the actions description in the chat when rolling from the character sheet.