### PR TITLE
refactor: use new api for skills and eliminate console warnings

### DIFF
--- a/src/module/feature/skill-actions/skill-actions-data.ts
+++ b/src/module/feature/skill-actions/skill-actions-data.ts
@@ -1,5 +1,6 @@
 import { PartialBy } from "./utils";
 import { Rank } from "./globals";
+import { CharacterPF2e } from "@actor";
 
 export type ActionType = "A" | "D" | "T" | "F" | "R" | "";
 
@@ -17,7 +18,7 @@ export interface SkillActionData {
     icon: string;
     actionType: ActionType;
     variants: VariantData[];
-    actor: Actor;
+    actor: CharacterPF2e;
     translation?: string;
 }
 
@@ -29,48 +30,48 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         slug: "balance",
         compendiumId: "M76ycLAqHoAgbcej",
         icon: "freedom-of-movement",
-        variants: [{ proficiencyKey: "acr" }],
+        variants: [{ proficiencyKey: "acrobatics" }],
     },
     {
         slug: "escape",
         compendiumId: "SkZAQRkLLkmBQNB9",
         icon: "agile-feet",
-        variants: [{ proficiencyKey: "acr" }, { proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "acrobatics" }, { proficiencyKey: "athletics" }],
     },
     {
         slug: "squeeze",
         compendiumId: "kMcV8e5EZUxa6evt",
         actionType: "",
-        variants: [{ proficiencyKey: "acr", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "acrobatics", requiredRank: 1 }],
     },
     {
         slug: "tumble-through",
         compendiumId: "21WIfSu7Xd7uKqV8",
         icon: "unimpeded-stride",
-        variants: [{ proficiencyKey: "acr" }],
+        variants: [{ proficiencyKey: "acrobatics" }],
     },
     {
         slug: "maneuver-in-flight",
         compendiumId: "Qf1ylAbdVi1rkc8M",
         icon: "fleet-step",
-        variants: [{ proficiencyKey: "acr", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "acrobatics", requiredRank: 1 }],
     },
     // Arcana
     {
         slug: "borrow-an-arcane-spell",
         compendiumId: "OizxuPb44g3eHPFh",
         actionType: "",
-        variants: [{ proficiencyKey: "arc", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "arcana", requiredRank: 1 }],
     },
     {
         slug: "decipher-writing",
         compendiumId: "d9gbpiQjChYDYA2L",
         actionType: "",
         variants: [
-            { proficiencyKey: "arc", requiredRank: 1 },
-            { proficiencyKey: "occ", requiredRank: 1 },
-            { proficiencyKey: "rel", requiredRank: 1 },
-            { proficiencyKey: "soc", requiredRank: 1 },
+            { proficiencyKey: "arcana", requiredRank: 1 },
+            { proficiencyKey: "occultism", requiredRank: 1 },
+            { proficiencyKey: "religion", requiredRank: 1 },
+            { proficiencyKey: "society", requiredRank: 1 },
         ],
     },
     {
@@ -78,10 +79,10 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         compendiumId: "eReSHVEPCsdkSL4G",
         actionType: "",
         variants: [
-            { proficiencyKey: "arc", requiredRank: 1 },
-            { proficiencyKey: "nat", requiredRank: 1 },
-            { proficiencyKey: "occ", requiredRank: 1 },
-            { proficiencyKey: "rel", requiredRank: 1 },
+            { proficiencyKey: "arcana", requiredRank: 1 },
+            { proficiencyKey: "nature", requiredRank: 1 },
+            { proficiencyKey: "occultism", requiredRank: 1 },
+            { proficiencyKey: "religion", requiredRank: 1 },
         ],
     },
     {
@@ -89,22 +90,22 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         compendiumId: "Q5iIYCFdqJFM31GW",
         actionType: "",
         variants: [
-            { proficiencyKey: "arc", requiredRank: 1 },
-            { proficiencyKey: "nat", requiredRank: 1 },
-            { proficiencyKey: "occ", requiredRank: 1 },
-            { proficiencyKey: "rel", requiredRank: 1 },
+            { proficiencyKey: "arcana", requiredRank: 1 },
+            { proficiencyKey: "nature", requiredRank: 1 },
+            { proficiencyKey: "occultism", requiredRank: 1 },
+            { proficiencyKey: "religion", requiredRank: 1 },
         ],
     },
     {
         slug: "recall-knowledge",
         compendiumId: "1OagaWtBpVXExToo",
         variants: [
-            { proficiencyKey: "arc" },
-            { proficiencyKey: "cra" },
-            { proficiencyKey: "nat" },
-            { proficiencyKey: "occ" },
-            { proficiencyKey: "rel" },
-            { proficiencyKey: "soc" },
+            { proficiencyKey: "arcana" },
+            { proficiencyKey: "crafting" },
+            { proficiencyKey: "nature" },
+            { proficiencyKey: "occultism" },
+            { proficiencyKey: "religion" },
+            { proficiencyKey: "society" },
             { proficiencyKey: "lore" },
         ],
     },
@@ -113,10 +114,10 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         compendiumId: "gxtq81VAhpmNvEgA",
         actionType: "A",
         variants: [
-            { proficiencyKey: "arc", requiredRank: 1 },
-            { proficiencyKey: "nat", requiredRank: 1 },
-            { proficiencyKey: "occ", requiredRank: 1 },
-            { proficiencyKey: "rel", requiredRank: 1 },
+            { proficiencyKey: "arcana", requiredRank: 1 },
+            { proficiencyKey: "nature", requiredRank: 1 },
+            { proficiencyKey: "occultism", requiredRank: 1 },
+            { proficiencyKey: "religion", requiredRank: 1 },
         ],
     },
     // Athletics
@@ -124,86 +125,86 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         slug: "climb",
         compendiumId: "pprgrYQ1QnIDGZiy",
         icon: "heroic-feat",
-        variants: [{ proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "athletics" }],
     },
     {
         slug: "force-open",
         compendiumId: "SjmKHgI7a5Z9JzBx",
         icon: "indestructibility",
-        variants: [{ proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "athletics" }],
     },
     {
         slug: "disarm",
         compendiumId: "Dt6B1slsBy8ipJu9",
         icon: "perfect-strike",
-        variants: [{ proficiencyKey: "ath", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "athletics", requiredRank: 1 }],
     },
     {
         slug: "grapple",
         compendiumId: "PMbdMWc2QroouFGD",
         icon: "remove-fear",
-        variants: [{ proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "athletics" }],
     },
     {
         slug: "high-jump",
         compendiumId: "2HJ4yuEFY1Cast4h",
         actionType: "D",
         icon: "jump",
-        variants: [{ proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "athletics" }],
     },
     {
         slug: "long-jump",
         compendiumId: "JUvAvruz7yRQXfz2",
         actionType: "D",
         icon: "longstrider",
-        variants: [{ proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "athletics" }],
     },
     {
         slug: "shove",
         compendiumId: "7blmbDrQFNfdT731",
         icon: "ki-strike",
-        variants: [{ proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "athletics" }],
     },
     {
         slug: "swim",
         compendiumId: "c8TGiZ48ygoSPofx",
         icon: "waters-of-prediction",
-        variants: [{ proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "athletics" }],
     },
     {
         slug: "trip",
         compendiumId: "ge56Lu1xXVFYUnLP",
         icon: "natures-enmity",
-        variants: [{ proficiencyKey: "ath" }],
+        variants: [{ proficiencyKey: "athletics" }],
     },
     // Crafting
     {
         slug: "craft",
         compendiumId: "rmwa3OyhTZ2i2AHl",
         actionType: "",
-        variants: [{ proficiencyKey: "cra", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "crafting", requiredRank: 1 }],
     },
     {
         slug: "earn-income",
         compendiumId: "QyzlsLrqM0EEwd7j",
         actionType: "",
         variants: [
-            { proficiencyKey: "cra", requiredRank: 1 },
+            { proficiencyKey: "crafting", requiredRank: 1 },
             { proficiencyKey: "lore", requiredRank: 1 },
-            { proficiencyKey: "prf", requiredRank: 1 },
+            { proficiencyKey: "performance", requiredRank: 1 },
         ],
     },
     {
         slug: "identify-alchemy",
         compendiumId: "Q4kdWVOf2ztIBFg1",
         actionType: "",
-        variants: [{ proficiencyKey: "cra", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "crafting", requiredRank: 1 }],
     },
     {
         slug: "repair",
         compendiumId: "bT3skovyLUtP22ME",
         actionType: "",
-        variants: [{ proficiencyKey: "cra" }],
+        variants: [{ proficiencyKey: "crafting" }],
     },
     // Deception
     {
@@ -212,17 +213,17 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         variants: [
             {
                 label: "xdy-pf2e-workbench.skillActions.Settings.variants.createADiversion.distractingWords",
-                proficiencyKey: "dec",
+                proficiencyKey: "deception",
                 extra: { variant: "distracting-words" },
             },
             {
                 label: "xdy-pf2e-workbench.skillActions.Settings.variants.createADiversion.gesture",
-                proficiencyKey: "dec",
+                proficiencyKey: "deception",
                 extra: { variant: "gesture" },
             },
             {
                 label: "xdy-pf2e-workbench.skillActions.Settings.variants.createADiversion.trick",
-                proficiencyKey: "dec",
+                proficiencyKey: "deception",
                 extra: { variant: "trick" },
             },
         ],
@@ -231,51 +232,51 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         slug: "feint",
         compendiumId: "QNAVeNKtHA0EUw4X",
         icon: "delay-consequence",
-        variants: [{ proficiencyKey: "dec", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "deception", requiredRank: 1 }],
     },
     {
         slug: "impersonate",
         compendiumId: "AJstokjdG6iDjVjE",
         actionType: "",
-        variants: [{ proficiencyKey: "dec" }],
+        variants: [{ proficiencyKey: "deception" }],
     },
     {
         slug: "lie",
         compendiumId: "ewwCglB7XOPLUz72",
         actionType: "",
-        variants: [{ proficiencyKey: "dec" }],
+        variants: [{ proficiencyKey: "deception" }],
     },
     // Diplomacy
     {
         slug: "gather-information",
         compendiumId: "plBGdZhqq5JBl1D8",
         actionType: "",
-        variants: [{ proficiencyKey: "dip" }],
+        variants: [{ proficiencyKey: "diplomacy" }],
     },
     {
         slug: "make-an-impression",
         compendiumId: "OX4fy22hQgUHDr0q",
         actionType: "",
-        variants: [{ proficiencyKey: "dip" }],
+        variants: [{ proficiencyKey: "diplomacy" }],
     },
     {
         slug: "request",
         compendiumId: "DCb62iCBrJXy0Ik6",
         icon: "cackle",
-        variants: [{ proficiencyKey: "dip" }],
+        variants: [{ proficiencyKey: "diplomacy" }],
     },
     // Intimidation
     {
         slug: "coerce",
         compendiumId: "tHCqgwjtQtzNqVvd",
         actionType: "",
-        variants: [{ proficiencyKey: "itm" }],
+        variants: [{ proficiencyKey: "intimidation" }],
     },
     {
         slug: "demoralize",
         compendiumId: "2u915NdUyQan6uKF",
         icon: "blind-ambition",
-        variants: [{ proficiencyKey: "itm" }],
+        variants: [{ proficiencyKey: "intimidation" }],
     },
     // Lore
     // Medicine
@@ -283,37 +284,37 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         slug: "administer-first-aid",
         compendiumId: "MHLuKy4nQO2Z4Am1",
         actionType: "D",
-        variants: [{ proficiencyKey: "med" }],
+        variants: [{ proficiencyKey: "medicine" }],
     },
     {
         slug: "treat-disease",
         compendiumId: "TC7OcDa7JlWbqMaN",
         actionType: "",
-        variants: [{ proficiencyKey: "med", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "medicine", requiredRank: 1 }],
     },
     {
         slug: "treat-poison",
         compendiumId: "KjoCEEmPGTeFE4hh",
-        variants: [{ proficiencyKey: "med", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "medicine", requiredRank: 1 }],
     },
     {
         slug: "treat-wounds",
         compendiumId: "1kGNdIIhuglAjIp9",
         actionType: "",
-        variants: [{ proficiencyKey: "med", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "medicine", requiredRank: 1 }],
     },
     // Nature
     {
         slug: "command-an-animal",
         compendiumId: "q9nbyIF0PEBqMtYe",
-        variants: [{ proficiencyKey: "nat" }],
+        variants: [{ proficiencyKey: "nature" }],
     },
     // Occultism
     // Performance
     {
         slug: "perform",
         compendiumId: "EEDElIyin4z60PXx",
-        variants: [{ proficiencyKey: "prf" }],
+        variants: [{ proficiencyKey: "performance" }],
     },
     // Religion
     // Society
@@ -321,196 +322,196 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         slug: "create-forgery",
         compendiumId: "ftG89SjTSa9DYDOD",
         actionType: "",
-        variants: [{ proficiencyKey: "soc", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "society", requiredRank: 1 }],
     },
     {
         slug: "subsist",
         compendiumId: "49y9Ec4bDii8pcD3",
         actionType: "",
-        variants: [{ proficiencyKey: "soc" }, { proficiencyKey: "sur" }],
+        variants: [{ proficiencyKey: "society" }, { proficiencyKey: "survival" }],
     },
     // Stealth
     {
         slug: "conceal-an-object",
         compendiumId: "qVNVSmsgpKFGk9hV",
-        variants: [{ proficiencyKey: "ste" }],
+        variants: [{ proficiencyKey: "stealth" }],
     },
     {
         slug: "hide",
         compendiumId: "XMcnh4cSI32tljXa",
         icon: "zealous-conviction",
-        variants: [{ proficiencyKey: "ste" }],
+        variants: [{ proficiencyKey: "stealth" }],
     },
     {
         slug: "sneak",
         compendiumId: "VMozDqMMuK5kpoX4",
         icon: "invisibility",
-        variants: [{ proficiencyKey: "ste" }],
+        variants: [{ proficiencyKey: "stealth" }],
     },
     // Survival
     {
         slug: "cover-tracks",
         compendiumId: "SB7cMECVtE06kByk",
         actionType: "",
-        variants: [{ proficiencyKey: "sur", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "survival", requiredRank: 1 }],
     },
     {
         slug: "sense-direction",
         compendiumId: "fJImDBQfqfjKJOhk",
         actionType: "",
-        variants: [{ proficiencyKey: "sur" }],
+        variants: [{ proficiencyKey: "survival" }],
     },
     {
         slug: "track",
         compendiumId: "EA5vuSgJfiHH7plD",
         actionType: "",
-        variants: [{ proficiencyKey: "sur", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "survival", requiredRank: 1 }],
     },
     // Thievery
     {
         slug: "disable-device",
         compendiumId: "cYdz2grcOcRt4jk6",
         actionType: "D",
-        variants: [{ proficiencyKey: "thi", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "thievery", requiredRank: 1 }],
     },
     {
         slug: "palm-an-object",
         compendiumId: "ijZ0DDFpMkWqaShd",
-        variants: [{ proficiencyKey: "thi" }],
+        variants: [{ proficiencyKey: "thievery" }],
     },
     {
         slug: "pick-a-lock",
         compendiumId: "2EE4aF4SZpYf0R6H",
         actionType: "D",
         icon: "ward-domain",
-        variants: [{ proficiencyKey: "thi", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "thievery", requiredRank: 1 }],
     },
     {
         slug: "steal",
         compendiumId: "RDXXE7wMrSPCLv5k",
-        variants: [{ proficiencyKey: "thi" }],
+        variants: [{ proficiencyKey: "thievery" }],
     },
     // Feat based
     {
         slug: "battle-medicine",
         compendiumId: "wYerMk6F1RZb0Fwt",
-        variants: [{ proficiencyKey: "med", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "medicine", requiredRank: 1 }],
     },
     {
         slug: "battle-prayer",
         actionType: "A",
         compendiumId: "nBlzWZnmYuFHrMyV",
-        variants: [{ proficiencyKey: "rel", requiredRank: 3 }],
+        variants: [{ proficiencyKey: "religion", requiredRank: 3 }],
     },
     {
         slug: "bon-mot",
         compendiumId: "0GF2j54roPFIDmXf",
-        variants: [{ proficiencyKey: "dip" }],
+        variants: [{ proficiencyKey: "diplomacy" }],
     },
     {
         slug: "chromotherapy",
         actionType: "D",
         compendiumId: "RlFZ648UR0Q0YECL",
-        variants: [{ proficiencyKey: "med", requiredRank: 2 }],
+        variants: [{ proficiencyKey: "medicine", requiredRank: 2 }],
     },
     {
         slug: "diabolic-certitude",
         actionType: "F",
         compendiumId: "WxL8NMW9JQ5igu0C",
-        variants: [{ proficiencyKey: "rel", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "religion", requiredRank: 1 }],
     },
     {
         slug: "disturbing-knowledge",
         actionType: "D",
         compendiumId: "hkSuxXOc9qBleJbd",
-        variants: [{ proficiencyKey: "occ", requiredRank: 3 }],
+        variants: [{ proficiencyKey: "occultism", requiredRank: 3 }],
     },
     {
         slug: "encouraging-words",
         actionType: "A",
         compendiumId: "dUnT3HWMFD3d2eBJ",
-        variants: [{ proficiencyKey: "dip", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "diplomacy", requiredRank: 1 }],
     },
     {
         slug: "evangelize",
         actionType: "A",
         compendiumId: "YgbcLfAEdi4xxvX5",
-        variants: [{ proficiencyKey: "dip", requiredRank: 3 }],
+        variants: [{ proficiencyKey: "diplomacy", requiredRank: 3 }],
     },
     {
         slug: "eye-for-numbers",
         actionType: "A",
         compendiumId: "0N8TtGSk5enoLBZ8",
-        variants: [{ proficiencyKey: "soc", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "society", requiredRank: 1 }],
     },
     {
         slug: "juggle",
         actionType: "A",
         compendiumId: "AYb8PmGJ37HwIMwj",
-        variants: [{ proficiencyKey: "prf", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "performance", requiredRank: 1 }],
     },
     {
         slug: "legendary-negotiation",
         compendiumId: "A0TNeMNvyY8QpmLz",
         actionType: "T",
-        variants: [{ proficiencyKey: "dip", requiredRank: 4 }],
+        variants: [{ proficiencyKey: "diplomacy", requiredRank: 4 }],
     },
     {
         slug: "no-cause-for-alarm",
         compendiumId: "6ON8DjFXSMITZleX",
         actionType: "T",
-        variants: [{ proficiencyKey: "dip", requiredRank: 1 }],
+        variants: [{ proficiencyKey: "diplomacy", requiredRank: 1 }],
     },
     {
         slug: "quick-mount",
         compendiumId: "G9l2g7sDpPVbZJza",
         actionType: "A",
-        variants: [{ proficiencyKey: "nat", requiredRank: 2 }],
+        variants: [{ proficiencyKey: "nature", requiredRank: 2 }],
     },
     {
         slug: "reveal-true-name",
         compendiumId: "5s8FqK4YZTVOvP0v",
         actionType: "D",
         variants: [
-            { proficiencyKey: "arc", requiredRank: 1 },
-            { proficiencyKey: "nat", requiredRank: 1 },
-            { proficiencyKey: "occ", requiredRank: 1 },
-            { proficiencyKey: "rel", requiredRank: 1 },
+            { proficiencyKey: "arcana", requiredRank: 1 },
+            { proficiencyKey: "nature", requiredRank: 1 },
+            { proficiencyKey: "occultism", requiredRank: 1 },
+            { proficiencyKey: "religion", requiredRank: 1 },
         ],
     },
     {
         slug: "sacred-defense",
         actionType: "A",
         compendiumId: "gHBdjbEnIK8clK8u",
-        variants: [{ proficiencyKey: "rel", requiredRank: 3 }],
+        variants: [{ proficiencyKey: "religion", requiredRank: 3 }],
     },
     {
         slug: "sanctify-water",
         actionType: "A",
         compendiumId: "P9dVBWB8nYZt4AFA",
-        variants: [{ proficiencyKey: "rel", requiredRank: 3 }],
+        variants: [{ proficiencyKey: "religion", requiredRank: 3 }],
     },
     {
         slug: "scare-to-death",
         compendiumId: "mZttsiWl1ql5NvrH",
         actionType: "A",
-        variants: [{ proficiencyKey: "itm", requiredRank: 4 }],
+        variants: [{ proficiencyKey: "intimidation", requiredRank: 4 }],
     },
     {
         slug: "treat-condition",
         actionType: "D",
         compendiumId: "rfnEcjxIFqwlJwJT",
-        variants: [{ proficiencyKey: "med" }],
+        variants: [{ proficiencyKey: "medicine" }],
     },
     {
         slug: "trick-magic-item",
         compendiumId: "uR62fVC9FyQAMCO1",
         actionType: "A",
         variants: [
-            { proficiencyKey: "arc", requiredRank: 1 },
-            { proficiencyKey: "nat", requiredRank: 1 },
-            { proficiencyKey: "occ", requiredRank: 1 },
-            { proficiencyKey: "rel", requiredRank: 1 },
+            { proficiencyKey: "arcana", requiredRank: 1 },
+            { proficiencyKey: "nature", requiredRank: 1 },
+            { proficiencyKey: "occultism", requiredRank: 1 },
+            { proficiencyKey: "religion", requiredRank: 1 },
         ],
     },
     {
@@ -518,10 +519,10 @@ export const SKILL_ACTIONS_DATA: Omit<SkillActionDataParameters, "actor">[] = [
         compendiumId: "OtV7esAwza1U6Kwr",
         actionType: "A",
         variants: [
-            { proficiencyKey: "arc", requiredRank: 1 },
-            { proficiencyKey: "nat", requiredRank: 1 },
-            { proficiencyKey: "occ", requiredRank: 1 },
-            { proficiencyKey: "rel", requiredRank: 1 },
+            { proficiencyKey: "arcana", requiredRank: 1 },
+            { proficiencyKey: "nature", requiredRank: 1 },
+            { proficiencyKey: "occultism", requiredRank: 1 },
+            { proficiencyKey: "religion", requiredRank: 1 },
         ],
     },
 ];

--- a/src/module/feature/skill-actions/skill-actions.ts
+++ b/src/module/feature/skill-actions/skill-actions.ts
@@ -5,6 +5,7 @@ import { MODULENAME } from "../../xdy-pf2e-workbench";
 import { ItemPF2e } from "@item";
 import { ActionsIndex } from "./actions-index";
 import { ItemSummaryData } from "@item/data";
+import { CharacterSkill } from "@actor/character/types";
 
 const ACTION_ICONS: Record<ActionType, string> = {
     A: "OneAction",
@@ -211,23 +212,22 @@ export class SkillAction {
         return !!this.actor.items.find((item) => item.slug === slug);
     }
 
-    private getSkills(proficiencyKey: string) {
+    private getSkills(proficiencyKey: string): CharacterSkill[] {
         // @ts-ignore
-        const skills = this.actor.system.skills;
+        const skills = this.actor.skills;
         if (proficiencyKey === "lore") {
             // @ts-ignore
             return Object.values(skills).filter((skill) => skill.lore);
         } else {
-            return [skills[proficiencyKey]];
+            return [skills[proficiencyKey]].filter((s): s is CharacterSkill => !!s);
         }
     }
 
     buildVariants(data) {
-        this.getSkills(data.proficiencyKey).forEach((skill: any) => {
+        for (const skill of this.getSkills(data.proficiencyKey)) {
             const requiredRank = data.requiredRank ?? 0;
-
-            const hasRank =
-                skill.rank >= requiredRank || (requiredRank === 1 && this.actorHasItem("clever-improviser"));
+            const rank = skill.rank;
+            const hasRank = rank >= requiredRank || (requiredRank === 1 && this.actorHasItem("clever-improviser"));
             if (!hasRank) {
                 return;
             }
@@ -245,11 +245,11 @@ export class SkillAction {
             if (
                 this.actor.items
                     .filter((x: any) => x.slug === "assurance")
-                    .filter((x: any) => x.flags.pf2e.rulesSelections.assurance === skill.name)?.length > 0
+                    .filter((x: any) => x.flags.pf2e.rulesSelections.assurance === skill.slug)?.length > 0
             ) {
                 this.variants.addAssuranceVariant(skill, data.extra);
             }
-        });
+        }
     }
 }
 

--- a/src/module/feature/skill-actions/variants.ts
+++ b/src/module/feature/skill-actions/variants.ts
@@ -1,14 +1,14 @@
-import { CharacterSkillData } from "./globals";
+import { CharacterSkill } from "@actor/character/types";
 import { ModifierPF2e } from "./pf2e";
 
 export class VariantsCollection extends Array<Variant> {
-    addBasicVariant(skill: CharacterSkillData, extra: Record<string, unknown> | undefined, label: string | undefined) {
-        const modifier = (skill.value >= 0 ? " +" : " ") + skill.value;
-        label = label ? game.i18n.localize(label) : skill.label ? game.i18n.localize(skill.label) : skill.name;
+    addBasicVariant(skill: CharacterSkill, extra: Record<string, unknown> | undefined, label: string | undefined) {
+        const modifier = (skill.check.mod >= 0 ? " +" : " ") + skill.check.mod;
+        label = label ? game.i18n.localize(label) : skill.label;
         this.push(new Variant(`${label}${modifier}`, skill, extra));
     }
 
-    addMapVariant(skill: CharacterSkillData, extra: Record<string, unknown> | undefined, map: number) {
+    addMapVariant(skill: CharacterSkill, extra: Record<string, unknown> | undefined, map: number) {
         const modifier = new ModifierPF2e({
             label: game.i18n.localize("PF2E.MultipleAttackPenalty"),
             modifier: map,
@@ -18,7 +18,7 @@ export class VariantsCollection extends Array<Variant> {
         this.push(new Variant(label, skill, extra, [modifier]));
     }
 
-    addAssuranceVariant(skill: CharacterSkillData, extra: Record<string, unknown> | undefined) {
+    addAssuranceVariant(skill: CharacterSkill, extra: Record<string, unknown> | undefined) {
         const proficiency = skill.modifiers.find((m) => m.type === "proficiency");
         const assuranceTotal = 10 + (proficiency?.modifier || 0);
         // Assurance has no i18n translation in system
@@ -32,14 +32,14 @@ export class VariantsCollection extends Array<Variant> {
 
 export class Variant {
     label: string;
-    skill: CharacterSkillData;
+    skill: CharacterSkill;
     extra?: Record<string, unknown>;
     modifiers: ModifierPF2e[];
     assuranceTotal: number;
 
     constructor(
         label: string,
-        skill: CharacterSkillData,
+        skill: CharacterSkill,
         extra: Record<string, unknown> | undefined,
         modifiers: ModifierPF2e[] = [],
         assuranceTotal = 0


### PR DESCRIPTION
New behavior is that the console remains pristine. The slug/name warnings for statistic were driving me mad.

![image](https://user-images.githubusercontent.com/1286721/207244462-4e06d378-73e0-4226-822d-2e33d53b168b.png)
