### PR TITLE
fix: Fix regression in NPC mystification pre/post

### DIFF
--- a/src/module/feature/tokenMystificationHandler/traits-name-generator.ts
+++ b/src/module/feature/tokenMystificationHandler/traits-name-generator.ts
@@ -29,8 +29,6 @@ async function fixesPreAndPost(settingkey: string): Promise<string> {
                     const draw = await (<RollTable>document).draw({ displayChat: false });
                     if (draw && draw?.results[0]) {
                         return draw?.results[0].getChatText();
-                    } else {
-                        return <string>fixSetting;
                     }
                 }
             }
@@ -38,10 +36,9 @@ async function fixesPreAndPost(settingkey: string): Promise<string> {
             const draw = await table?.draw({ displayChat: false });
             if (draw && draw?.results[0]) {
                 return draw?.results[0].getChatText();
-            } else {
-                return <string>fixSetting;
             }
         }
+	return <string>fixSetting;
     }
     return "";
 }


### PR DESCRIPTION
3ddf19a7 had introduced a regression where prefix/postfix settings were ignored if they were simple strings instead of table names. In particular, the examples given in the settings page ("Unknown" as prefix and "Creature" as postfix) had no effect. This fixes that.