### PR TITLE
Fix absolute vs relative link bug in module thumbnail image

### DIFF
--- a/static/module.json
+++ b/static/module.json
@@ -243,7 +243,7 @@
     {
       "type": "setup",
       "caption": "PF2e Workbench",
-      "thumbnail": "/modules/xdy-pf2e-workbench/assets/media/pf2e_workbench_cover_compressed.webp"
+      "thumbnail": "modules/xdy-pf2e-workbench/assets/media/pf2e_workbench_cover_compressed.webp"
     }
   ],
   "flags": {


### PR DESCRIPTION
URLs of module assets should not start with `/` (forward backslash), it should be skipped.  When it is included, the image only loads successfully in localhost and in servers that set it up to be in e.g. `www.example.com` but not `www.example.com/myfoundryinstall`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

No.