### PR TITLE
Fix URL for background image

### DIFF
--- a/src/packs/data/xdy-customizable-macros/customizableBasicActionMacros.macro
+++ b/src/packs/data/xdy-customizable-macros/customizableBasicActionMacros.macro
@@ -349,7 +349,7 @@ const content = `
 <!--suppress ALL -->
 <style>
   .pf2e-bg .window-content {
-    background: url(../systems/pf2e/assets/sheet/background.webp);
+    background: url(systems/pf2e/assets/sheet/background.webp);
   }
 
   .action-list {


### PR DESCRIPTION
It's not right if the foundry base URL isn't at the server's root.  It's not right ever, but it only breaks in the non-root install.

The base URL for the style url() call is the foundry server base. Doesn't need to be a "../" in front.  I.e., the URL is:

http://server.com/../systems/pf2e/assets/sheet/background.webp

The invalid "../" is removed by the css url function so it works.  But for a non-root install, one might have:

http://server.com/fvtt/../systems/pf2e/assets/sheet/background.webp

And now the "../" isn't invalid, so it stays, and the URL is wrong.

* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
background image url incorect

* **What is the new behavior (if this is a feature change)?**
url is correct

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
no

* **Other information**:
