### PR TITLE
Order Basic Action Macro dialog by columns

### DIFF
--- a/src/module/xdy-pf2e-workbench.ts
+++ b/src/module/xdy-pf2e-workbench.ts
@@ -438,7 +438,4 @@ function registerHandlebarsHelpers() {
         }
         return false;
     });
-    Handlebars.registerHelper("xdy_count", function (element: any[]) {
-        return element.length;
-    })
 }

--- a/src/styles/xdy-pf2e-workbench.scss
+++ b/src/styles/xdy-pf2e-workbench.scss
@@ -170,7 +170,8 @@
     margin-bottom: 8px;
     grid-column-gap: 2px;
     grid-auto-flow: column;
-    //grid-template-rows: repeat(9, 1fr);
+    grid-template-rows: repeat(calc(var(--bam-count) / var(--bam-columns)), 1fr);
+    grid-template-columns: repeat(var(--bam-columns), 1fr);
     button.glow {
         --color-glow1: 35;
         --color-glow2: 50;
@@ -233,19 +234,20 @@
 
 @for $i from 1 through 40 {
     @container bam-dialog (width <= #{bamWidth($i+1)}) and (width > #{bamWidth($i)}) {
-        @for $j from 1 through 60 {
-            .action-list[data-bam-count="#{$j}"] {
-                //grid-template-columns: repeat($i, 1fr);
-                grid-template-rows: repeat(#{math.ceil(math.div($j, $i))}, 1fr);
-            }
+        .action-list {
+            --bam-columns:#{$i};
         }
     }
 }
 
 @container bam-dialog (width < #{bamWidth(1)}){
-    @for $j from 1 through 60 {
-        .action-list[data-bam-count="#{$j}"] {
-            grid-template-rows: repeat(#{$j}, 1fr);
-        }
+    .action-list {
+	--bam-columns: 1;
+    }
+}
+
+@container bam-dialog (width > #{bamWidth(41)}) {
+    .action-list {
+        --bam-columns: 41;
     }
 }

--- a/static/templates/macros/bam/index.hbs
+++ b/static/templates/macros/bam/index.hbs
@@ -7,22 +7,22 @@
 {{/if}}
 <section class="bam-body">
     {{#if tabView }}
-        <div class="tab encounter active" data-group="primary" data-tab="encounter">
-            <div class="action-list" data-bam-count="{{xdy_count encounter}}">
+        <div class="tab encounter active" data-group="primary" data-tab="encounter" style="--bam-count:{{encounter.length}};">
+            <div class="action-list">
                 {{#each encounter}}
                     {{> actionButton this}}
                 {{/each}}
             </div>
         </div>
-        <div class="tab exploration" data-group="primary" data-tab="exploration">
-            <div class="action-list" data-bam-count="{{xdy_count exploration}}">
+        <div class="tab exploration" data-group="primary" data-tab="exploration" style="--bam-count:{{exploration.length}};">
+            <div class="action-list">
                 {{#each exploration}}
                     {{> actionButton this}}
                 {{/each}}
             </div>
         </div>
-        <div class="tab downtime" data-group="primary" data-tab="downtime">
-            <div class="action-list" data-bam-count="{{xdy_count downtime}}">
+        <div class="tab downtime" data-group="primary" data-tab="downtime" style="--bam-count:{{downtime.length}};">
+            <div class="action-list">
                 {{#each downtime}}
                     {{> actionButton this}}
                 {{/each}}
@@ -30,24 +30,24 @@
         </div>
     {{else}}
         <h3><a class="item" data-tab="encounter">Encounter</a></h3>
-        <div class="tab encounter active" data-group="primary" data-tab="encounter">
-            <div class="action-list" data-bam-count="{{xdy_count encounter}}">
+        <div class="tab encounter active" data-group="primary" data-tab="encounter" style="--bam-count:{{encounter.length}};">
+            <div class="action-list">
                 {{#each encounter}}
                     {{> actionButton this}}
                 {{/each}}
             </div>
         </div>
         <h3><a class="item" data-tab="exploration">Exploration</a></h3>
-        <div class="tab exploration active" data-group="primary" data-tab="exploration">
-            <div class="action-list" data-bam-count="{{xdy_count exploration}}">
+        <div class="tab exploration active" data-group="primary" data-tab="exploration" style="--bam-count:{{exploration.length}};">
+            <div class="action-list">
                 {{#each exploration}}
                     {{> actionButton this}}
                 {{/each}}
             </div>
         </div>
         <h3><a class="item" data-tab="downtime">Downtime</a></h3>
-        <div class="tab downtime active" data-group="primary" data-tab="downtime">
-            <div class="action-list" data-bam-count="{{xdy_count downtime}}">
+        <div class="tab downtime active" data-group="primary" data-tab="downtime" style="--bam-count:{{downtime.length}};">
+            <div class="action-list">
                 {{#each downtime}}
                     {{> actionButton this}}
                 {{/each}}


### PR DESCRIPTION
This is much simpler than that existing code and doesn't result in huge css file with thousands of classes.

Currently the css file is 7675 lines and 250 kB, almost as large as the total mjs code.  After this change css files is 425 lines and only 8 kB.

The dialog template injects the number of BAM items as a CSS variable, with style="...", in the div that contains the BAM action list.

Then the limited math that can be done in CSS itself is enough to figure out how many rows and columns should be used for the grid.  This can be done in just a single class, using CSS variables for the number of items (from above) and the number of columns for the window width, which the existing per-window width classes specify.

I probably wouldn't go up so such a huge number of columns.  Does anyone actually want a window with 40 columns that stretches across two monitors and then some?  Seems like 10 columns or less should look fine.