### PR TITLE
Fix rounding in BAM column count

### DIFF
--- a/src/styles/xdy-pf2e-workbench.scss
+++ b/src/styles/xdy-pf2e-workbench.scss
@@ -170,7 +170,7 @@
     margin-bottom: 8px;
     grid-column-gap: 2px;
     grid-auto-flow: column;
-    grid-template-rows: repeat(calc(var(--bam-count) / var(--bam-columns)), 1fr);
+    grid-template-rows: repeat(calc((var(--bam-count) + var(--bam-columns) / 2 - 0.01) / var(--bam-columns)), 1fr);
     grid-template-columns: repeat(var(--bam-columns), 1fr);
     button.glow {
         --color-glow1: 35;


### PR DESCRIPTION
The spec for repeat() is to round to nearest, not round up.  So for example, 36 actions in 5 columns gives 36/5 = 7.2 -> 7 rows, not 8 like it should be.

By adding just a bit less than 1/2 the divisor, it will have the effect of rounding up.  Now we get (36 + 2.5 - 0.01) / 5 = 7.698 -> 8.

And if it was 4 column, then we'd get (36 + 2.0 - 0.01) / 4 = 9.4975 -> 9, which is also the right value.