### PR TITLE
Add conditional visibility of settings on menu forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf dist/*",
     "watch": "npm run build:packs && vite build --watch --mode development",
     "hot": "vite serve",
-    "lint": "npm run lint:ts && npm run lint:jsonn && npm run prettier:scss",
+    "lint": "npm run lint:ts && npm run lint:json && npm run prettier:scss",
     "lint:ts": "eslint ./build ./src --ext .ts",
     "lint:json": "eslint ./static --ext .json --no-eslintrc --plugin json --rule \"json/*: error\"",
     "lint:fix": "eslint ./build ./src --ext .ts --fix"

--- a/src/module/settings/automation-client.ts
+++ b/src/module/settings/automation-client.ts
@@ -4,6 +4,12 @@ import { SettingsMenuPF2eWorkbench } from "./menu.js";
 export class WorkbenchClientAutomationSettings extends SettingsMenuPF2eWorkbench {
     static override namespace = "automationClientSettings";
 
+    static override get defaultOptions() {
+        return fu.mergeObject(super.defaultOptions, {
+            height: "fit-content",
+        });
+    }
+
     public static override get settings(): Record<string, SettingRegistration> {
         return {
             // NOTE Do NOT rename this without talking to Symon S, his macros for Spellstrike and Eldritch shot parse for workbench and its settings to avoid double rolling damage.

--- a/src/module/settings/automation-world.ts
+++ b/src/module/settings/automation-world.ts
@@ -218,4 +218,17 @@ export class WorkbenchWorldAutomationSettings extends SettingsMenuPF2eWorkbench 
             },
         };
     }
+
+    static override readonly hiddenList = {
+        autoGainDyingAtZeroHP: {
+            type: "select",
+            falsy: "no",
+            list: [
+                "nonLethalIsNotLethal",
+                "autoGainDyingAtZeroHPIfCriticallyHitOneMore",
+                "autoGainDyingIfTakingDamageWhenAlreadyDying",
+                "autoGainDyingIgnoresTargeting",
+            ],
+        },
+    };
 }

--- a/src/module/settings/automation-world.ts
+++ b/src/module/settings/automation-world.ts
@@ -219,7 +219,7 @@ export class WorkbenchWorldAutomationSettings extends SettingsMenuPF2eWorkbench 
         };
     }
 
-    static override readonly hiddenList = {
+    static override readonly hidelist = {
         autoGainDyingAtZeroHP: {
             type: "select",
             falsy: "no",

--- a/src/module/settings/houseRules.ts
+++ b/src/module/settings/houseRules.ts
@@ -4,6 +4,12 @@ import { SettingsMenuPF2eWorkbench } from "./menu.js";
 export class WorkbenchHouseRulesSettings extends SettingsMenuPF2eWorkbench {
     static override namespace = "houseRulesSettings";
 
+    static override get defaultOptions() {
+        return fu.mergeObject(super.defaultOptions, {
+            height: "fit-content",
+        });
+    }
+
     public static override get settings(): Record<string, SettingRegistration> {
         return {
             keeleysHeroPointRule: {

--- a/src/module/settings/menu.ts
+++ b/src/module/settings/menu.ts
@@ -11,6 +11,11 @@ export interface MenuTemplateData extends FormApplicationData {
     settings: SettingsTemplateData[];
 }
 
+/**
+ * @var {string} type   The HTMLElement's type (e.g. "input" or "select"). Defaults to "input".
+ * @var {string} falsy  The falsy value. Useful for select-type elements. Defaults to false.
+ * @var {string[]} list A list with the setting IDs that should be toggled when the setting is changed.
+ */
 interface HideListTemplateData {
     [key: string]: {
         type?: string;

--- a/src/module/settings/menu.ts
+++ b/src/module/settings/menu.ts
@@ -61,12 +61,12 @@ export class SettingsMenuPF2eWorkbench extends FormApplication {
         form.style.display = !boolean ? "none" : "";
     }
 
-    static readonly hiddenList: Object = {} as HideListTemplateData;
+    static readonly hidelist: Object = {} as HideListTemplateData;
 
     // @ts-ignore
     static hook(...args: any): HookCallback<unknown[]> {
         const html = args[1];
-        Object.entries(this.hiddenList).forEach(([k, v]) => {
+        Object.entries(this.hidelist).forEach(([k, v]) => {
             const setting = game.settings.get("xdy-pf2e-workbench", k) !== (v.falsy ?? false);
             const settingCheckbox = html.find(`.form-fields [name="${k}"]`);
             for (const form of v.list) {

--- a/src/module/settings/menu.ts
+++ b/src/module/settings/menu.ts
@@ -31,7 +31,7 @@ export class SettingsMenuPF2eWorkbench extends FormApplication {
             id: `${this.namespace}-settings`, // lgtm [js/mixed-static-instance-this-access]
             template: `modules/xdy-pf2e-workbench/templates/menu.hbs`,
             classes: ["form", "xdy-pf2e-workbench", "settings-menu"],
-            width: 560,
+            width: 780,
             height: 680,
             closeOnSubmit: true,
             resizable: true,

--- a/src/module/settings/qol-world.ts
+++ b/src/module/settings/qol-world.ts
@@ -173,7 +173,7 @@ export class WorkbenchQolWorldSettings extends SettingsMenuPF2eWorkbench {
         };
     }
 
-    static override readonly hiddenList = {
+    static override readonly hidelist = {
         castPrivateSpell: {
             list: [
                 "castPrivateSpellAutoRevealIfKnown",

--- a/src/module/settings/qol-world.ts
+++ b/src/module/settings/qol-world.ts
@@ -172,4 +172,19 @@ export class WorkbenchQolWorldSettings extends SettingsMenuPF2eWorkbench {
             },
         };
     }
+
+    static override readonly hiddenList = {
+        castPrivateSpell: {
+            list: [
+                "castPrivateSpellAutoRevealIfKnown",
+                "castPrivateSpellAutoRevealPartyMembersThatKnowSpell",
+                "castPrivateSpellAutoRevealPartyMembersThatKnowSpell",
+                "castPrivateSpellHideName",
+                "castPrivateSpellAlwaysFor",
+            ],
+        },
+        castPrivateSpellWithPublicMessage: {
+            list: ["castPrivateSpellWithPublicMessageShowToGM", "castPrivateSpellWithPublicMessageShowTraits"],
+        },
+    };
 }

--- a/src/module/xdy-pf2e-workbench.ts
+++ b/src/module/xdy-pf2e-workbench.ts
@@ -210,6 +210,7 @@ Hooks.once("init", async (_actor: ActorPF2e) => {
     // Hooks that always run
     Hooks.on("renderSettingsMenuPF2eWorkbench", (_app: any, html: JQuery, _settings: SettingsMenuPF2eWorkbench) => {
         toggleMenuSettings(html, _settings);
+        _app.setPosition();
     });
 
     // Hooks.on("renderSettingsConfig", (_app: any, html: JQuery) => {

--- a/src/styles/xdy-pf2e-workbench.scss
+++ b/src/styles/xdy-pf2e-workbench.scss
@@ -153,6 +153,25 @@
     display: none !important;
 }
 
+.xdy-pf2e-workbench {
+    &.settings-menu {
+        .window-content {
+          padding: 0;
+        }
+        form {
+            height: 100%;
+            section {
+              padding: 1rem;
+              overflow: hidden auto;
+            }
+            footer {
+              margin: 1rem;
+              flex: 0;
+            }
+        }
+    }
+}
+
 
 .bam-dialog {
     container: bam-dialog / inline-size;

--- a/static/templates/menu.hbs
+++ b/static/templates/menu.hbs
@@ -1,7 +1,6 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
-    <p class="instructions">{{localize instructions}}</p>
+<form class="flexcol" autocomplete="off" onsubmit="event.preventDefault();">
+    <section class="content">
     {{#each settings as |setting|}}
-        <!-- {{setting.key}} -->
         <div class="form-group">
             <label for="{{setting.key}}">{{localize setting.name}}</label>
             <div class="form-fields">
@@ -27,12 +26,11 @@
             <p class="notes">{{localize setting.hint}}</p>
         </div>
     {{/each}}
-    <div class="form-group buttons">
+    </section>
+
+    <footer class="sheet-footer buttons">
         <button type="submit" name="submit">
             <i class="far fa-save"></i> {{localize "SETTINGS.Save"}}
         </button>
-        <button type="reset" name="reset">
-            <i class="fas fa-undo"></i> {{localize "PF2E.SETTINGS.ResetChanges"}}
-        </button>
-    </div>
+    </footer>
 </form>


### PR DESCRIPTION
### **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Added styling to menus so the Save Changes button is always displayed, similar to Core Foundry's Settings menu.
  - Set a height value equal to Foundry's Settings menu.
    - Client Automation menu acts differently due to its variable size. It can be larger than other menus if all settings are available, or smaller otherwise. There isn't a proper way to set its size on first render (V12 will fix this).
    - House Rules menu has a smaller height due to having fewer settings available.
- Added conditional visibility to settings on Menus.
  - Currently only added Hide Lists to QoL and World Automation menus.

### **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No.

### **Other information**:
Be sure to check `HideListTemplateData` interface for an explanation of its elements.