### PR TITLE
Add correct traits to Dirge of Doom Aura RE

### DIFF
--- a/src/packs/leveldb/xdy-pf2e-workbench-items/Aura__Dirge_of_Doom_wOcAf3pf04cTM4Uk.json
+++ b/src/packs/leveldb/xdy-pf2e-workbench-items/Aura__Dirge_of_Doom_wOcAf3pf04cTM4Uk.json
@@ -11,6 +11,11 @@
       {
         "key": "Aura",
         "radius": 30,
+        "traits": [
+          "mental",
+          "fear",
+          "emotion"
+        ],
         "slug": "aura-dirge-of-doom",
         "effects": [
           {


### PR DESCRIPTION
**What does this change?**

This makes Dirge of Doom apply correctly per the rules.

**What kind of change does this PR introduce?**

This adds traits to the Aura RE of the Dirge Aura Effect.

**What is the current behavior?**

Dirge of Doom applies to all enemies in the radius instead of applying to only enemies susceptible to Dirge.

**What is the new behavior?**

Creatures now correctly check the Aura Traits for whether Dirge can be applied to them or not.

**Does this PR introduce a breaking change?**

No, existing effects should work fine.
