### PR TITLE
feat: BAM: Get rid eval() for actions

### DIFF
--- a/src/module/feature/macros/basicActionMacros.ts
+++ b/src/module/feature/macros/basicActionMacros.ts
@@ -5,7 +5,7 @@
 
 import { MODULENAME } from "../../xdy-pf2e-workbench.js";
 import { ActorPF2e } from "@actor";
-import { Action } from "@actor/actions/types.js";
+import { Action, ActionVariant } from "@actor/actions/types.js";
 import { CharacterSkill } from "@actor/character/types.js";
 import { ModifierPF2e } from "@actor/modifiers.js";
 import { Statistic } from "@system/statistic/statistic.js";
@@ -84,7 +84,7 @@ type MacroAction = {
     altSkillAndFeat?: { skill: string; feat: string }[];
     name: string;
     icon: string;
-    action: string | Function | string[] | Action | undefined;
+    action: string | Function | string[] | Action | ActionVariant | undefined;
     module?: string;
     best?: number;
     whoIsBest?: string;
@@ -149,14 +149,14 @@ export async function basicActionMacros() {
             actionType: "skill_untrained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.AdministerFirstAidStabilize`),
             skill: "Medicine",
-            action: 'game.pf2e.actions.get("administer-first-aid").use({ event, variant: "stabilize"})',
+            action: game.pf2e.actions.get("administer-first-aid")?.variants.get("stabilize"),
             icon: "systems/pf2e/icons/features/feats/treat-wounds.webp",
         },
         {
             actionType: "skill_untrained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.AdministerFirstAidStopBleeding`),
             skill: "Medicine",
-            action: 'game.pf2e.actions.get("administer-first-aid").use({ event, variant: "stop-bleeding"})',
+            action: game.pf2e.actions.get("administer-first-aid")?.variants.get("stop-bleeding"),
             icon: "systems/pf2e/icons/conditions/persistent-damage.webp",
         },
         {
@@ -242,21 +242,21 @@ export async function basicActionMacros() {
             actionType: "skill_untrained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.CreateADiversionDistractingWords`),
             skill: "Deception",
-            action: 'game.pf2e.actions.get("create-a-diversion").use({ event, variant: "distracting-words" })',
+            action: game.pf2e.actions.get("create-a-diversion")?.variants.get("distracting-words"),
             icon: "icons/skills/social/wave-halt-stop.webp",
         },
         {
             actionType: "skill_untrained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.CreateADiversionGesture`),
             skill: "Deception",
-            action: 'game.pf2e.actions.get("create-a-diversion").use({ event, variant: "gesture" })',
+            action: game.pf2e.actions.get("create-a-diversion")?.variants.get("gesture"),
             icon: "icons/skills/social/wave-halt-stop.webp",
         },
         {
             actionType: "skill_untrained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.CreateADiversionTrick`),
             skill: "Deception",
-            action: 'game.pf2e.actions.get("create-a-diversion").use({ event, variant: "trick" })',
+            action: game.pf2e.actions.get("create-a-diversion")?.variants.get("trick"),
             icon: "systems/pf2e/icons/spells/charming-words.webp",
         },
         {
@@ -410,7 +410,7 @@ export async function basicActionMacros() {
             actionType: "skill_untrained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.Perform`),
             skill: "Performance",
-            action: 'game.pf2e.actions.get("perform").use({ event, variant: "singing" })',
+            action: game.pf2e.actions.get("perform")?.variants.get("singing"),
             icon: "icons/skills/trades/music-singing-voice-blue.webp",
         },
         {

--- a/src/module/feature/macros/basicActionMacros.ts
+++ b/src/module/feature/macros/basicActionMacros.ts
@@ -5,7 +5,7 @@
 
 import { MODULENAME } from "../../xdy-pf2e-workbench.js";
 import { ActorPF2e } from "@actor";
-import { Action, ActionVariant } from "@actor/actions/types.js";
+import { Action, ActionUseOptions, ActionVariant } from "@actor/actions/types.js";
 import { CharacterSkill } from "@actor/character/types.js";
 import { ModifierPF2e } from "@actor/modifiers.js";
 import { Statistic } from "@system/statistic/statistic.js";
@@ -91,6 +91,8 @@ type MacroAction = {
     showMAP?: boolean;
     showExploration?: boolean;
     showDowntime?: boolean;
+    // Optional parameters for an Action.use() call
+    options?: Partial<ActionUseOptions>;
     actionType?: "basic" | "skill_untrained" | "skill_trained" | "other";
     actionTitle?: string;
 };
@@ -125,10 +127,7 @@ function prepareActions(selectedActor: ActorPF2e, bamActions: MacroAction[]): Ma
         .sort((a, b) => a.name.localeCompare(b.name, game.i18n.lang));
 
     actionsToUse.forEach((x) => {
-        const action =
-            typeof x.action === "string" && x.action.includes("use(") ? eval(x.action.split(".use")[0]) : x.action;
-
-        const traits = action?.traits ?? [];
+        const traits = (x as any)?.action?.traits ?? [];
         x.showMAP = traits.includes("attack");
         x.showDowntime = traits.includes("downtime");
         x.showExploration = traits.includes("exploration");
@@ -262,28 +261,32 @@ export async function basicActionMacros() {
             actionType: "skill_trained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.DecipherWritingArcana`),
             skill: "Arcana",
-            action: 'game.pf2e.actions.get("decipher-writing").use({ event, statistic: "arcana" })',
+            action: game.pf2e.actions.get("decipher-writing"),
+            options: { statistic: "arcana" },
             icon: "icons/skills/trades/academics-book-study-runes.webp",
         },
         {
             actionType: "skill_trained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.DecipherWritingOccultism`),
             skill: "Occultism",
-            action: 'game.pf2e.actions.get("decipher-writing").use({ event, statistic: "occultism" })',
+            action: game.pf2e.actions.get("decipher-writing"),
+            options: { statistic: "occultism" },
             icon: "icons/skills/trades/academics-book-study-purple.webp",
         },
         {
             actionType: "skill_trained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.DecipherWritingReligion`),
             skill: "Religion",
-            action: 'game.pf2e.actions.get("decipher-writing").use({ event, statistic: "religion" })',
+            action: game.pf2e.actions.get("decipher-writing"),
+            options: { statistic: "religion" },
             icon: "systems/pf2e/icons/equipment/other/spellbooks/thresholds-of-truth.webp",
         },
         {
             actionType: "skill_trained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.DecipherWritingSociety`),
             skill: "Society",
-            action: 'game.pf2e.actions.get("decipher-writing").use({ event, statistic: "society" })',
+            action: game.pf2e.actions.get("decipher-writing"),
+            options: { statistic: "society" },
             icon: "icons/skills/trades/academics-study-reading-book.webp",
         },
         {
@@ -507,14 +510,16 @@ export async function basicActionMacros() {
             actionType: "skill_untrained",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.SubsistSociety`),
             skill: "Society",
-            action: 'game.pf2e.actions.get("subsist").use({ event, statistic: "society" })',
+            action: game.pf2e.actions.get("subsist"),
+            options: { statistic: "society" },
             icon: "icons/environment/settlement/building-rubble.webp",
         },
         {
             actionType: "basic",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.SubsistSurvival`),
             skill: "Survival",
-            action: 'game.pf2e.actions.get("subsist").use({ event, statistic: "survival" })',
+            action: game.pf2e.actions.get("subsist"),
+            options: { statistic: "survival" },
             icon: "icons/environment/wilderness/camp-improvised.webp",
         },
         {
@@ -703,6 +708,7 @@ export async function basicActionMacros() {
                                 event,
                                 multipleAttackPenalty: mapValue,
                                 skipDialog: event.skipDialog,
+                                ...action.options,
                             })
                             .then();
                     } else {

--- a/src/module/feature/macros/basicActionMacros.ts
+++ b/src/module/feature/macros/basicActionMacros.ts
@@ -91,7 +91,6 @@ type MacroAction = {
     showMAP?: boolean;
     showExploration?: boolean;
     showDowntime?: boolean;
-    extra?: string;
     actionType?: "basic" | "skill_untrained" | "skill_trained" | "other";
     actionTitle?: string;
 };
@@ -724,7 +723,6 @@ export async function basicActionMacros() {
                                 event,
                                 actors: [selectedActor],
                                 skill: action.skill.toLocaleLowerCase(),
-                                variant: action.extra,
                             });
                         }
                     }

--- a/src/module/feature/macros/basicActionMacros.ts
+++ b/src/module/feature/macros/basicActionMacros.ts
@@ -84,7 +84,7 @@ type MacroAction = {
     altSkillAndFeat?: { skill: string; feat: string }[];
     name: string;
     icon: string;
-    action: string | Function | string[] | Action | ActionVariant | undefined;
+    action: Function | string[] | Action | ActionVariant | undefined;
     module?: string;
     best?: number;
     whoIsBest?: string;
@@ -176,7 +176,7 @@ export async function basicActionMacros() {
             actionType: "other",
             name: game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.actions.AidPF2eMacros`),
             skill: "",
-            action: "game.activemacros.aid(_token.actor)",
+            action: (options) => game["activemacros"].aid(options.actors?.[0]),
             module: "pf2e-macros",
             icon: "systems/pf2e/icons/spells/efficient-apport.webp",
         },
@@ -658,21 +658,7 @@ export async function basicActionMacros() {
                 const action = (button, event) => {
                     const action = actionsToUse[button.dataset.action];
                     const current = action.action;
-                    if (typeof current === "string") {
-                        if (!current.includes("(")) {
-                            const macro = game.macros.get(current);
-                            if (!macro) {
-                                ui.notifications.error(
-                                    game.i18n.localize(`${MODULENAME}.macros.basicActionMacros.gmMustImport`),
-                                );
-                                return;
-                            }
-                            macro?.execute(event);
-                        } else {
-                            // Ugh
-                            eval(current);
-                        }
-                    } else if (Array.isArray(current)) {
+                    if (Array.isArray(current)) {
                         const macroName = current[0];
                         const compendiumName = current[1];
                         const pack = game.packs.get(compendiumName);


### PR DESCRIPTION
Allow the "action" to be an ActionVariant too.  Then an eval'ed string that calls a specific variant of a game.pf2e.actions Action can be replaced with the ActionVariant object.

Add a new `options` field to the MacroAction object, with options for an Action `use()` call.  Most of eval'ed string actions left are `.use()` calls with a `statistic` option supplied.  This can now be done with action as the Action object and an options field with the statistic.

The special processing of strings with ".use(" can go away now, as there are none left.

* **Please check if the PR fulfills these requirements**

- [X ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Cleanup

* **What is the current behavior?** (You can also link to an open issue here)
Unchanged.

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No.

* **Other information**:
