### PR TITLE
Fix Game Paused Icon

### DIFF
--- a/src/styles/xdy-pf2e-workbench.scss
+++ b/src/styles/xdy-pf2e-workbench.scss
@@ -3,8 +3,8 @@
 :root {
     --xdy-pf2e-workbench-pause: "";
     --xdy-pf2e-workbench-pause-background: "initial";
-    --xdy-pf2e-workbench-pause-bottom: "";
-    --xdy-pf2e-workbench-pause-figcaption-top: "";
+    --xdy-pf2e-workbench-pause-bottom: 10%;
+    --xdy-pf2e-workbench-pause-figcaption-top: 0%;
 }
 
 #pause {


### PR DESCRIPTION
Set default values for pause text variables in the stylesheet, this way they are set properly despite the feature being disabled.

* **Please check if the PR fulfills these requirements**

- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)
[The game paused icon is messed up](https://github.com/xdy/xdy-pf2e-workbench/issues/1361)

* **What is the new behavior (if this is a feature change)?**
Sets the default values for the custom game paused variables in the style sheet,

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No

* **Other information**:
