### PR TITLE
fix: Update of auto apply persistent damage and recovery roll

### DIFF
--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -60,6 +60,10 @@ export const preCreateChatMessageHook = (message: ChatMessagePF2e, data: any, _o
         handlePrivateSpellcasting(data, message).then();
     }
 
+    if (game.settings.get(MODULENAME, "applyPersistentDamage")) {
+        persistentDamage(message);
+    }
+
     if (reminderTargetingEnabled) {
         proceed = reminderTargeting(message, String(game.settings.get(MODULENAME, "reminderTargeting")));
     }
@@ -116,10 +120,6 @@ export function renderChatMessageHook(message: ChatMessagePF2e, jq: JQuery) {
     const html = <HTMLElement>jq.get(0);
     // Only acts on latest message, but can't be in createChatMessageHook as that doesn't get triggered for some reason.
     persistentHealing(message, Boolean(game.settings.get(MODULENAME, "applyPersistentHealing")));
-
-    if (game.settings.get(MODULENAME, "applyPersistentDamage")) {
-        persistentDamage(message);
-    }
 
     deprecatedDyingHandlingRenderChatMessageHook(message);
 

--- a/src/module/xdy-pf2e-workbench.ts
+++ b/src/module/xdy-pf2e-workbench.ts
@@ -108,7 +108,8 @@ export function updateHooks(cleanSlate = false) {
         "preCreateChatMessage",
         gs.get(MODULENAME, "castPrivateSpell") ||
             gs.get(MODULENAME, "reminderTargeting") !== "no" ||
-            gs.get(MODULENAME, "reminderCannotAttack") === "cancelAttack",
+            gs.get(MODULENAME, "reminderCannotAttack") === "cancelAttack" ||
+            gs.get(MODULENAME, "applyPersistentDamage"),
         preCreateChatMessageHook,
     );
 


### PR DESCRIPTION
Current pf2e codebase allows this to be simplified.

Instead of hooking renderChatMessage, hook preCreateChatMessage.  This way we don't have to worry about running on old messages that were scrolled back to.  And preCreate is run just on on the client of the user sending the message, not all clients, so there's less performance impact.

The extra server update to set a flag when the message is handled isn't needed, since preCreate is only run once.

Give the argument a type, so typescript can do type checking.

Rather than look in the flavor text for certain html to find persistent damage, use `isDamageRoll` plus a damage instance with `persistent` and `options.evaluatePersistent` set.

Instead of searching conditions flavor html to find the condition by translated name, it can be found directly from the `origin.uuid` flag.

The All/GM/Players/None and per-user settings do not work as they are described.  It turns out they didn't really work before, but no one seemed to noticed, likely because the part that didn't work wasn't widely used.

How it actually worked is that the "All" or "GM" choice will use the GM's checkbox for all actors.  The non-GM users' settings are (almost) always ignored.  The "Players" choice will effectively turn it off.  Only in the unlikely case of no GMs being logged in, and a player ending their own turn, would the Players setting and a player user's checkbox get used. However, it wouldn't necessarily be the same user's checkbox as the one who clicked next turn.  It could be a different user who logged in first.

This commit changes it so that in addition to All and GM using the GM's setting, so will Players, instead of Players meaning always off.

Probably would be nice to fix this at some point.

* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)


* **Other information**:
