### PR TITLE
fix: Unify apply persistent damage/healing, add roll options

### DIFF
--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -11,7 +11,7 @@ import {
     damageCardExpand,
     mystifyNpcItems,
 } from "./feature/qolHandler/index.js";
-import { autoRollDamage, persistentDamage, persistentHealing } from "./feature/damageHandler/index.js";
+import { autoRollDamage, persistentDamageHealing } from "./feature/damageHandler/index.js";
 import { reduceFrightened } from "./feature/conditionHandler/index.js";
 import {
     mangleNamesInChatMessage,
@@ -60,12 +60,11 @@ export const preCreateChatMessageHook = (message: ChatMessagePF2e, data: any, _o
         handlePrivateSpellcasting(data, message).then();
     }
 
-    if (game.settings.get(MODULENAME, "applyPersistentDamage")) {
-        persistentDamage(message);
-    }
-
-    if (game.settings.get(MODULENAME, "applyPersistentHealing")) {
-        persistentHealing(message);
+    if (
+        game.settings.get(MODULENAME, "applyPersistentDamage") ||
+        game.settings.get(MODULENAME, "applyPersistentHealing")
+    ) {
+        persistentDamageHealing(message);
     }
 
     if (reminderTargetingEnabled) {

--- a/static/lang/cn.json
+++ b/static/lang/cn.json
@@ -53,8 +53,6 @@
         "name": "添加用户目标"
       },
       "applyPersistentHealing": {
-        "FastHealingLabel": "获得快速愈合",
-        "RegenerationLabel": "获得再生",
         "wasHealed": "{healing}治疗已自动生效。",
         "name": "系统掷出的持续治疗自动生效。",
         "hint": "是否让系统掷出的持续治疗自动生效的客户端设置。保存设置以显示/隐藏其他选项。"

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -273,10 +273,8 @@
         "name": "Ziele des Benutzers hinzufügen"
       },
       "applyPersistentHealing": {
-        "FastHealingLabel": "Schnelle Heilung erhalten",
         "hint": "Client-Einstellung um anhaltende Heilung automatisch vom System anwenden zu lassen. Einstellungen speichern um zusätzliche Optionen ein- bzw. auszublenden.",
         "name": "Automatisches anwenden von anhaltender Heilung, welche vom System ausgewürfelt wird.",
-        "RegenerationLabel": "Regeneration erhalten",
         "wasHealed": "{healing} Heilung wurde automatisch angewendet."
       },
       "customPauseImage": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -172,10 +172,8 @@
         "name": "... and automatically roll recovery after that."
       },
       "applyPersistentHealing": {
-        "FastHealingLabel": "Received fast healing",
         "hint": "Client setting to automatically apply persistent healing rolled by the system. Save settings to show/hide additional options.",
         "name": "Automatically apply persistent healing rolled by the system.",
-        "RegenerationLabel": "Received regeneration",
         "wasHealed": "{healing} healing was automatically applied."
       },
       "autoCollapseItemChatCardContent": {

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -47,10 +47,8 @@
         "wasDamaged": "{damage} dégâts ont été automatiquement appliqués"
       },
       "applyPersistentHealing": {
-        "FastHealingLabel": "a reçu guérison accélérée",
         "hint": "Appliquer automatiquement les soins persistants lancés par le système. Sauvegarder les réglages pour afficher/cacher des options supplémentaires.",
         "name": "Appliquer automatiquement les soins persistants lancés par le système.",
-        "RegenerationLabel": "A reçu régénération",
         "wasHealed": "{healing} de soins ont été appliqués automatiquement."
       },
       "autoCollapseItemChatCardContent": {

--- a/static/lang/pl.json
+++ b/static/lang/pl.json
@@ -177,11 +177,9 @@
         "hint": "Wybierz, kto może ustawić opcję automatycznego naliczania obrażeń przy trafieniu. Zapisz ustawienia, aby wyświetlić/ukryć dodatkowe opcje w menu ustawień automatyzacji klienta."
       },
       "applyPersistentHealing": {
-        "RegenerationLabel": "Otrzymana regeneracja",
         "wasHealed": "Leczenie {healing} zostało zastosowane automatycznie.",
         "name": "Automatycznie zastosuj trwałe leczenie używane przez system.",
         "hint": "Ustawienie klienta w celu automatycznego stosowania trwałego leczenia przez system. Zapisz ustawienia, aby wyświetlić/ukryć dodatkowe opcje.",
-        "FastHealingLabel": "Otrzymał szybkie uzdrowienie"
       },
       "autoGainDyingAtZeroHPIfCriticallyHitOneMore": {
         "no": "Nie",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -34,10 +34,8 @@
         "wasDamaged": "{damage} de dano foi aplicado automaticamente"
       },
       "applyPersistentHealing": {
-        "FastHealingLabel": "Recebeu cura acelerada",
         "hint": "Automaticamente aplica cura persistente. Salve a configuração para mostrar/ocultar opções adicionais.",
         "name": "Aplicar cura persistente",
-        "RegenerationLabel": "Recebeu regeneração",
         "wasHealed": "{healing} de cura foi aplicado automaticamente."
       },
       "autoCollapseItemChatCardContent": {

--- a/static/lang/zh_Hant.json
+++ b/static/lang/zh_Hant.json
@@ -188,10 +188,8 @@
         "wasDamaged": "{damage}傷害已自動生效"
       },
       "applyPersistentHealing": {
-        "FastHealingLabel": "獲得快速癒合",
         "hint": "是否讓系統擲出的持續治療自動生效的客戶端設定。儲存設定以顯示/隱藏其他選項。",
         "name": "系統擲出的持續治療自動生效。",
-        "RegenerationLabel": "獲得再生",
         "wasHealed": "{healing}治療已自動生效。"
       },
       "autoCollapseItemChatCardContent": {


### PR DESCRIPTION
Now that there are REs that can trigger on damage-received and healing-received, having the right roll options set when taking the damage/healing matters.  The auto apply feature wasn't getting any of them.  Fix that.

Combine the persistent healing and damage functions, since a lot of the code is shared.

Use the heal flavor i18n identifier from PF2e system, so that the translations don't need to also be added to the module and kept up to date with every language in the pf2e system.

Move the hook to preCreateChatMessage.  This way it only runs on the single client of the user who is sending the notification, which is typically the GM.  The system already figures out a user to send the damage roll, so we can just have the same user apply the damage too.

* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)


* **Other information**:
