### PR TITLE
fix: Make BAM work with Dorako UI

### DIFF
--- a/src/styles/xdy-pf2e-workbench.scss
+++ b/src/styles/xdy-pf2e-workbench.scss
@@ -189,47 +189,65 @@
     grid-auto-flow: column;
     grid-template-rows: repeat(calc((var(--bam-count) + var(--bam-columns) / 2 - 0.01) / var(--bam-columns)), 1fr);
     grid-template-columns: repeat(var(--bam-columns), 1fr);
-    button.glow {
-        --color-glow1: 35;
-        --color-glow2: 50;
-        animation: glow2 alternate infinite 2s;
-        z-index: 1;
-    }
-}
 
-.bam-action-btn {
-    margin: 1px auto;
-    width: 100%;
-    height: fit-content;
-    box-shadow: inset 0 0 0 1px rgb(0 0 0 / 50%);
-    text-shadow: none;
-    border: #000;
-    color: #fff;
-    display: flex;
-    align-items: center;
-    white-space: nowrap;
-    overflow: hidden;
+    .bam-map-wrapper {
+        display: flex;
+        gap: 5px;
+        margin: 0 auto;
+        width: 100%;
 
-    &:hover {
-        text-shadow: 0 0 2px #fff;
+        button {
+            width: unset;
+
+            &:first-child {
+                flex: 1 1 160px;
+            }
+        }
     }
 
-    img {
-        margin-right: 5px;
-    }
-}
+    button.bam-action-btn {
+        margin: 1px auto;
+        height: fit-content;
+        box-shadow: inset 0 0 0 1px rgb(0 0 0 / 50%);
+        text-shadow: none;
+        border: #000;
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+        overflow: hidden;
 
-.bam-map-wrapper {
-    display: flex;
-    gap: 5px;
-    margin: 0 auto;
-    width: 100%;
+        &:hover {
+            text-shadow: 0 0 2px #fff;
+        }
+        &:glow {
+            --color-glow1: 35;
+            --color-glow2: 50;
+            animation: glow2 alternate infinite 2s;
+            z-index: 1;
+        }
+        &[data-rank="0"], &[data-rank] {
+            background: var(--color-proficiency-untrained);
+            color: var(--text-light);
+        }
+        &[data-rank="1"] {
+            background: var(--color-proficiency-trained);
+            color: var(--text-light);
+        }
+        &[data-rank="2"] {
+            background: var(--color-proficiency-expert);
+            color: var(--text-light);
+        }
+        &[data-rank="3"] {
+            background: var(--color-proficiency-master);
+            color: var(--text-light);
+        }
+        &[data-rank="4"] {
+            background: var(--color-proficiency-legendary);
+            color: var(--text-light);
+        }
 
-    button {
-        width: unset;
-
-        &:first-child {
-            flex: 1 1 160px;
+        img {
+            margin-right: 5px;
         }
     }
 }

--- a/static/templates/macros/bam/actionButton.hbs
+++ b/static/templates/macros/bam/actionButton.hbs
@@ -1,40 +1,24 @@
-{{#*inline "colorPalette"}}
-    {{#if (eq rank 0)}}
-        #424242
-    {{else if (eq rank 1)}}
-        #171f67
-    {{else if (eq rank 2)}}
-        #3c005e
-    {{else if (eq rank 3)}}
-        #664400
-    {{else if (eq rank 4)}}
-        #5e0000
-    {{else}}
-        #424242
-    {{/if}}
-{{/inline}}
 {{#*inline "actionName"}}{{action.name}} {{#xdy_ifne skill xdy_undefined}}({{signedInteger
     bonus}}){{/xdy_ifne}}{{/inline}}
 {{#*inline "actionTooltip"}}{{> actionName}} {{ifThen best (localize "xdy-pf2e-workbench.macros.basicActionMacros.YouAreTheBestInYourParty")""}}{{/inline}}
 {{#if action.showMAP}}
     <div class="bam-map-wrapper">
-        <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="0"
-                style="background:{{> colorPalette rank=skill.rank}}" data-tooltip="{{> actionTooltip}}"><img
+        <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="0" 
+                data-rank="{{skill.rank}}" data-tooltip="{{> actionTooltip}}"><img
             src="{{coalesce action.icon "systems/pf2e/icons/actions/craft/unknown-item.webp"}}" height="24"
             width="24"
             alt="{{> actionName}}"/>{{> actionName}}</button>
         <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="-5"
-                style="background:{{> colorPalette rank=skill.rank}}" data-tooltip="{{> actionTooltip}} {{localize
+                data-rank="{{skill.rank}}" data-tooltip="{{> actionTooltip}} {{localize
             "xdy-pf2e-workbench.macros.basicActionMacros.second"}}">{{localize
             "xdy-pf2e-workbench.macros.basicActionMacros.second"}}</button>
         <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="-10"
-                style="background:{{> colorPalette rank=skill.rank}}" data-tooltip="{{> actionTooltip}} {{localize
+                data-rank="{{skill.rank}}" data-tooltip="{{> actionTooltip}} {{localize
             "xdy-pf2e-workbench.macros.basicActionMacros.third"}}">{{localize
             "xdy-pf2e-workbench.macros.basicActionMacros.third"}}</button>
     </div>
 {{else}}
-    <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}"
-            style="background:{{> colorPalette rank=skill.rank}}"
+    <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-rank="{{skill.rank}}"
             data-tooltip="{{> actionTooltip}}">
         <img src="{{coalesce action.icon "systems/pf2e/icons/actions/craft/unknown-item.webp"}}" height="24"
              alt="{{name}}"/>{{> actionName}}


### PR DESCRIPTION
The way it did the background color and the choice of selectors made it problematic to theme BAM.

Instead of adding a style background directly to the buttons, give them data properies with the skill rank.  Then use that in the css to select colors.  Which now use var names from the pf2e css that match the abilities tab on the char sheet, instead of copying the color hex codes.

With the foreground and background color in the same place, it's possible to override neither or both.  But overriding one, so that a light theme foreground is combined with a dark theme background, shouldn't happen.

* **Please check if the PR fulfills these requirements**

- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)


* **Other information**:
