### PR TITLE
Add Token Mystification Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ A demo video of most features: https://www.youtube.com/watch?v=WzDq2N1X07s
           can also be added after the postfix, and optionally be kept when demystifying the creature. E.g. 'Skeletal
           Champion' could become 'Jack the Mindless Undead Skeleton 23'. Note that player owned tokens will not be
           mystified.
+        * There is a hook called `xdy-pf2e-workbench.tokenCreateMystification` that other modules can use. This is
+          triggered when a token is being created and is going to be mystified. If a module returns `false` the
+          token's name will not by mystified.
     * Option to use the mystified name in chat messages created from that npc (actions/spells). Relies on the original
       actor name being present in the text. Only works if the original npc name is actually used and correctly spelled
       in the message.

--- a/src/module/feature/tokenMystificationHandler/index.ts
+++ b/src/module/feature/tokenMystificationHandler/index.ts
@@ -151,7 +151,9 @@ export async function tokenCreateMystification(token: any) {
         (key === "ALWAYS" || isMystifyModifierKeyPressed()) &&
         (!game.keyboard?.downKeys.has("V") || game.keyboard?.downKeys.has("Insert"))
     ) {
-        await doMystification(token, false);
+        if (Hooks.call(`${MODULENAME}.tokenCreateMystification`, token)) {
+            await doMystification(token, false);
+        }
     }
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New Feature

* **What is the current behavior?** (You can also link to an open issue here)
When a token is created it will be mystified based on the module settings and if a key is pressed if setup to require a key to be pressed.

* **What is the new behavior (if this is a feature change)?**
Adds a hook that allows other modules to determine if the token should be mystified or not. The allows other modules like PF2e Bestiary Tracking to determine if a token should not be mystified because the party knows the name of the creature.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No

* **Other information**:
Addresses #1438 