### PR TITLE
Fix Private Spellcasting - Check All Prepared Slots

### DIFF
--- a/src/module/feature/qolHandler/handlePrivateSpellcasting.ts
+++ b/src/module/feature/qolHandler/handlePrivateSpellcasting.ts
@@ -125,11 +125,22 @@ function findPartyMembersWithSpell(origin: any) {
                 .some((item) => {
                     const spell = <SpellPF2e>(<unknown>item);
                     const entry = spell.spellcasting;
-                    return (
-                        !entry?.isPrepared ||
-                        (entry?.isPrepared &&
-                            entry?.system?.slots?.[`slot${spell.rank}`].prepared.some((s) => s.id === spell.id))
-                    );
+
+                    if (!entry?.isPrepared) {
+                        return true;
+                    } else {
+                        if (!entry?.system?.slots) {
+                            return false;
+                        }
+
+                        for (const [_, group] of Object.entries(entry.system.slots)) {
+                            if (group.prepared.some((s) => s.id === spell.id)) {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
                 });
         })
         .map((actor) => actor?.name);

--- a/src/module/feature/qolHandler/handlePrivateSpellcasting.ts
+++ b/src/module/feature/qolHandler/handlePrivateSpellcasting.ts
@@ -181,8 +181,6 @@ function buildSpellMessage(
 
         if (game.settings.get(MODULENAME, "castPrivateSpellWithPublicMessageShowTraits")) {
             const traits = Object.values(origin.system.traits.value);
-            if (game.settings.get(MODULENAME, "castPrivateSpellWithPublicMessageFilterTraits")) {
-            }
 
             content += game.i18n.localize(
                 game.i18n.format(`${MODULENAME}.SETTINGS.castPrivateSpellWithPublicMessageShowTraits.traitPart`, {

--- a/src/module/feature/qolHandler/handlePrivateSpellcasting.ts
+++ b/src/module/feature/qolHandler/handlePrivateSpellcasting.ts
@@ -26,7 +26,6 @@ export async function handlePrivateSpellcasting(data: any, message: ChatMessageP
             ? []
             : game.users
                   .filter((u) => u.active)
-
                   .filter((u) => u.id !== ChatMessage.getWhisperRecipients("GM").map((u) => u.id)[0])
                   .map((u) => u.id);
         const author = game.userId;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)
Right now it checks only the prepared slots for the spell's rank. If a spell is auto-heightened or prepared in a higher slot this will cause issues since the spell in question might not be in spell slots that is being checked.

* **What is the new behavior (if this is a feature change)?**
Checks all prepared slots for the spell.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No