### PR TITLE
feat: Add option for Recall Knowledge breakdown style

### DIFF
--- a/src/module/settings/index.ts
+++ b/src/module/settings/index.ts
@@ -131,6 +131,20 @@ export function registerWorkbenchSettings() {
         onChange: () => updateHooks(),
     });
 
+    game.settings.register(MODULENAME, "rkBreakdown", {
+        name: `${MODULENAME}.macros.recallKnowledge.breakdown.name`,
+        hint: `${MODULENAME}.macros.recallKnowledge.breakdown.hint`,
+        scope: "world",
+        config: true,
+        default: "all",
+        type: String,
+        choices: {
+            all: game.i18n.localize(`${MODULENAME}.macros.recallKnowledge.breakdown.all`),
+            extra: game.i18n.localize(`${MODULENAME}.macros.recallKnowledge.breakdown.extra`),
+            none: game.i18n.localize(`${MODULENAME}.macros.recallKnowledge.breakdown.none`),
+        },
+    });
+
     game.settings.register(MODULENAME, "customPauseImage", {
         name: `${MODULENAME}.SETTINGS.customPauseImage.name`,
         hint: `${MODULENAME}.SETTINGS.customPauseImage.hint`,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -123,6 +123,15 @@
         "noSpellcastingEntry": "You must have either an NPC character sheet open and selected, or a single NPC token selected. Also, said NPC must have a spellcasting entry.",
         "generatedSpellbookFor": "Generated spellbook for {name}"
       },
+      "recallKnowledge": {
+        "breakdown": {
+          "name": "Recall Knowledge: Show roll breakdowns",
+          "hint": "Show a breakdown of the modifiers applied to each skill on a line below the result.",
+          "all": "All modifiers",
+          "extra": "Extra modifiers; omit skill and proficiency",
+          "none": "Don't show any modifiers"
+        }
+      },
       "refocus": {
         "regains": "Regains {focus} focus points.",
         "notPsychic": "spent at least {regain} focus points",


### PR DESCRIPTION
This controls the style of the roll breakdown shown by the Recall Knowledge macro.  It can show no modifiers, all modifiers, or only the extra modifiers beyond the standard skill and proficiency modifiers that are always present.

It's added to the settings of the BAM macro settings.  Maybe both RK and BAM settings should go on a new sub-menu?

* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
RK can't be configured.

* **What is the new behavior (if this is a feature change)?**
RK can be configured.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No.  Results unchanged with older version of RK macro.

* **Other information**:
