### PR TITLE
fix: Get rid of deprecation warning on settings submenus

### DIFF
--- a/static/templates/menu.hbs
+++ b/static/templates/menu.hbs
@@ -6,11 +6,7 @@
             <div class="form-fields">
                 {{#if setting.isSelect}}
                     <select name="{{setting.key}}">
-                        {{#select setting.value}}
-                            {{#each setting.choices as |label value|}}
-                                <option value="{{value}}">{{localize label}}</option>
-                            {{/each}}
-                        {{/select}}
+                        {{selectOptions setting.choices selected=setting.value}}
                     </select>
                 {{else if setting.isCheckbox}}
                     <input type="checkbox" name="{{setting.key}}" {{checked setting.value}} />


### PR DESCRIPTION
Switch to new handlebars helper selectOptions as foundry has deprecated the select helper in V12.  This one is simpler too.

* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)
Warning when opening submenu.

* **What is the new behavior (if this is a feature change)?**
No warning.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
no

* **Other information**:
