### PR TITLE
fix: Don't hide crafting item information

### DIFF
--- a/src/module/feature/qolHandler/index.ts
+++ b/src/module/feature/qolHandler/index.ts
@@ -4,7 +4,7 @@ import { PhysicalItemPF2e } from "@item";
 import { ChatMessagePF2e } from "@module/chat-message/index.js";
 
 export function chatCardDescriptionCollapse(html: HTMLElement) {
-    const hasCardContent = html.querySelectorAll(".card-content");
+    const hasCardContent = html.querySelectorAll(".card-content:not(span.flavor-text *)");
     if (hasCardContent.length > 0) {
         const effectItem = game.i18n.localize(`${MODULENAME}.effectItem`);
         if (String(game.settings.get(MODULENAME, "autoCollapseItemChatCardContent")) === "collapsedDefault") {


### PR DESCRIPTION
The craft *action* chat card has some information on the item being crafted that re-uses the html from an *item* chat card.  The collapse item chat card feature was hiding this bit inside the action card.  But because it wasn't an item chat card there was no way to unhide it.

Changing the selector to not hide item content inside flavor text will avoid this.

* **Please check if the PR fulfills these requirements**

- [X] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)


* **Other information**:
