### PR TITLE
fix: Fix logic for alt skills with feat in BAM

### DIFF
--- a/src/module/feature/macros/basicActionMacros.ts
+++ b/src/module/feature/macros/basicActionMacros.ts
@@ -121,15 +121,17 @@ function prepareActions(selectedActor: ActorPF2e, bamActions: MacroAction[]): Ma
     const actionsToUse = bamActions
         .filter((x) => {
             const hasSkill = selectedActor.skills?.[x.skill]?.rank ?? 0 > 0;
-            const hasAltSkillAndFeat =
-                x.altSkillAndFeat?.find((y) => selectedActor.skills?.[y.skill]?.rank) &&
-                x.altSkillAndFeat?.find((y) => selectedActor.itemTypes.feat.find((feat) => feat.slug === y.feat));
+            const hasAltSkillAndFeat = x.altSkillAndFeat?.some(
+                (y) =>
+                    selectedActor.skills?.[y.skill].rank &&
+                    selectedActor.itemTypes.feat.some((feat) => feat.slug === y.feat),
+            );
 
             return (
                 showUnusable ||
                 x.actionType !== "skill_trained" ||
                 (x.actionType === "skill_trained" && ["npc", "familiar"].includes(selectedActor.type)) ||
-                selectedActor.itemTypes.feat.find((feat) => feat.slug === "clever-improviser") ||
+                selectedActor.itemTypes.feat.some((feat) => feat.slug === "clever-improviser") ||
                 hasSkill ||
                 hasAltSkillAndFeat
             );


### PR DESCRIPTION
It was testing if the actor had any alt skill and then if the actor had any alt feat.  So being trained in Nature and having the Chirurgeon feat would count for using Treat Wounds.

Change this so after checking for the alt skill it then checks if the corresponding alt feat is present.  So being trained in Nature requires Natural Medicine to be present.

And use some() instead of find().

* **Please check if the PR fulfills these requirements**

- [X] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)


* **Other information**:
