### PR TITLE
feature: Put item collapse trigger on entire header row

### DIFF
--- a/src/module/feature/qolHandler/index.ts
+++ b/src/module/feature/qolHandler/index.ts
@@ -31,23 +31,23 @@ export function chatCardDescriptionCollapse(html: HTMLElement) {
                 }
             }
         }
-    }
-    html.addEventListener("click", (event) => {
-        const target = (event.target as HTMLElement).closest("h3");
-        if (target) {
-            const content: HTMLElement | undefined | null = target
-                .closest(".chat-message")
-                ?.querySelector(".card-content");
-            if (content) {
+
+        // Add listener for hide/unhide click
+        const header = html.querySelector(".card-header");
+        if (header instanceof HTMLElement) {
+            header.addEventListener("click", (event) => {
                 event.preventDefault();
-                content.style.display = content.style.display === "none" ? "block" : "none";
-                if (content.style.display === "none") {
-                    hasCardContent.forEach((content: HTMLElement) => (content.style.display = "none"));
-                }
-                toggleEyes(html);
-            }
+                header
+                    .closest(".chat-message")
+                    ?.querySelectorAll(".card-content")
+                    ?.forEach((content) => {
+                        if (content instanceof HTMLElement)
+                            content.style.display = content.style.display === "none" ? "block" : "none";
+                    });
+                toggleEyes(header);
+            });
         }
-    });
+    }
 }
 
 function toggleEyes(html: HTMLElement) {


### PR DESCRIPTION
The collapse click trigger for item chat cards was only the item name.  The icon to left of the name didn't trigger, nor did the eye icon on the right.  The eye was especially glaring as only the eye icon is the trigger for other types of collapsed chat cards.

Also improve the efficiency of the handler.  It was installing a click handler for any click anywhere in any chat card.  The handler will query the event and card and figure out if it was a click in the title of an item card.

Since we already figured out of the card was an item card, we can add a handler for only that type of card.  And it can be added to the header row only and not the entire card.

* **Please check if the PR fulfills these requirements**

- [X] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.

* **What is the current behavior?** (You can also link to an open issue here)
Only click item title to toggle collapse

* **What is the new behavior (if this is a feature change)?**
Also click on item icon or eye icon in the header row.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No.

* **Other information**:
