### PR TITLE
fix: Dirge of Doom effect didn't apply Frightened

### DIFF
--- a/src/packs/leveldb/xdy-pf2e-workbench-items/_Effect__Dirge_Of_Doom_Z2RXTsLcFQEU5Qaj.json
+++ b/src/packs/leveldb/xdy-pf2e-workbench-items/_Effect__Dirge_Of_Doom_Z2RXTsLcFQEU5Qaj.json
@@ -1,16 +1,11 @@
 {
   "_id": "Z2RXTsLcFQEU5Qaj",
-  "name": "[Effect] Dirge Of Doom",
+  "name": "Effect: Dirge Of Doom",
   "type": "effect",
   "img": "systems/pf2e/icons/spells/dirge-of-doom.webp",
   "effects": [],
   "folder": "3k9ymrOLXRMPWQkb",
   "sort": 100000,
-  "flags": {
-    "core": {
-      "sourceId": "Item.7rD5LtJVU6ZVEzqB"
-    }
-  },
   "system": {
     "description": {
       "gm": "",
@@ -26,7 +21,11 @@
       {
         "key": "GrantItem",
         "uuid": "Compendium.pf2e.conditionitems.Item.TBSHQspnbcqxsmjL",
-        "allowDuplicate": false
+        "allowDuplicate": true,
+        "inMemoryOnly": true,
+        "onDeleteActions": {
+          "grantee": "restrict"
+        }
       }
     ],
     "slug": null,
@@ -72,8 +71,7 @@
     "unidentified": false
   },
   "ownership": {
-    "default": 0,
-    "4PfYOttbS0OMIfVw": 3
+    "default": 0
   },
   "_stats": {
     "systemId": "pf2e",
@@ -81,8 +79,8 @@
     "coreVersion": "12.329",
     "createdTime": 1665671947295,
     "modifiedTime": 1721420361678,
-    "lastModifiedBy": "O7JRpbplwU9Cx8kQ",
-    "compendiumSource": "Item.7rD5LtJVU6ZVEzqB",
+    "lastModifiedBy": null,
+    "compendiumSource": "Compendium.xdy-pf2e-workbench.xdy-pf2e-workbench-items.Item.Z2RXTsLcFQEU5Qaj",
     "duplicateSource": null
   },
   "_key": "!items!Z2RXTsLcFQEU5Qaj"


### PR DESCRIPTION
Needed inMemoryOnly.  Also restict frightened from being removed when in the aura.  Allow duplicates so an already frightened creature gaining the effect will gain the "frightened that doesn't go away" from the effect in addition the the frightened that does go away that is already has.

And clean up some old fields.

* **Please check if the PR fulfills these requirements**

- [X] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)


* **Other information**:
