### PR TITLE
Always remember selected actor for basicActionMacros()

### DIFF
--- a/src/module/feature/macros/basicActionMacros.ts
+++ b/src/module/feature/macros/basicActionMacros.ts
@@ -760,6 +760,7 @@ export async function basicActionMacros() {
                         const mapValue = button.dataset.map ? -(Number.parseInt(button.dataset.map) / 5) : 0;
                         current.use({
                             event,
+                            actors: [selectedActor],
                             multipleAttackPenalty: mapValue,
                             skipDialog: event.skipDialog,
                             ...action.options,


### PR DESCRIPTION
The basicActionMacros() requires a selected (or user) actor to open, but it doesn't propagate this to most checks. This means that if the user selects something else, the check will use that actor as source. This seems wrong, especially since the dialog includes the name of the originally selected actor.

This PR uses the `actors` option to set the `actor` variable, which is respected by regular skill checks. Note that some third party macros, like the one used for demoralize, (incorrectly) apply their own selection logic, instead of using the supplied `actor`. It will have to be patched separately.