### PR TITLE
fix: BAM: Show current tab, adjust spacing

### DIFF
--- a/src/module/feature/macros/basicActionMacros.ts
+++ b/src/module/feature/macros/basicActionMacros.ts
@@ -751,8 +751,7 @@ export async function basicActionMacros() {
     };
     const content = await renderTemplate("modules/xdy-pf2e-workbench/templates/macros/bam/index.hbs", filteredData);
 
-    const { DialogV2 } = foundry.applications.api;
-    window.actionDialog = await DialogV2.wait({
+    window.actionDialog = await foundry.applications.api.DialogV2.wait({
         position: {
             width,
         },
@@ -809,6 +808,10 @@ export async function basicActionMacros() {
                             if (tab.dataset.tab === tabButton.dataset.tab) tab.classList.add("active");
                             else tab.classList.remove("active");
                         }
+                        for (const otherButton of html.querySelectorAll("a.item.active")) {
+                            if (otherButton !== tabButton) otherButton.classList.remove("active");
+                        }
+                        tabButton.classList.add("active");
                     });
                 }
             }

--- a/src/styles/xdy-pf2e-workbench.scss
+++ b/src/styles/xdy-pf2e-workbench.scss
@@ -181,14 +181,21 @@
     }
 }
 
-.bam-tabs h3 {
-    display: inline-block;
-    margin: 0 0 0.5rem;
-    line-height: 1;
+.bam-tabs.tabs h3 {
+    margin: 0.5rem 0 0.5rem 0;
+    a.active {
+        text-decoration: underline;
+    }
 }
 
 .bam-body {
     padding-top: 2px;
+    h3 {
+        margin: 1rem 0 0.5rem 0;
+        &:first-child {
+            margin-top: 0;
+        }
+    }
 }
 
 .bam-body .tab {
@@ -213,7 +220,7 @@
 
     .bam-map-wrapper {
         display: flex;
-        gap: 2px;
+        gap: 1px;
         margin: 0 auto;
         width: 100%;
 
@@ -234,6 +241,7 @@
     button.bam-action-btn {
         margin: 1px auto;
         height: fit-content;
+        min-height: 28px;
         width: 100%;
         box-shadow: inset 0 0 0 1px rgb(0 0 0 / 50%);
         text-shadow: none;


### PR DESCRIPTION
Highlight and underline the title of the currently selected tab.

Reduce button height to be the same as it was in V12.  V13 had made the buttons 14% taller.

Reduce the gap between the MAP buttons.

Adjust margin of the section headers in the non-tabbed layout.

* **Please check if the PR fulfills these requirements**

- [x ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes display.

* **What is the current behavior?** (You can also link to an open issue here)
BAM is off on V13.

* **What is the new behavior (if this is a feature change)?**
It looks better.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
no.

* **Other information**:
