### PR TITLE
fix: Auto-roll damage for all spells was also rolling damage for strikes

### DIFF
--- a/src/module/feature/damageHandler/index.ts
+++ b/src/module/feature/damageHandler/index.ts
@@ -76,7 +76,7 @@ export async function autoRollDamage(message: ChatMessagePF2e) {
 
             const rollForAllSpells =
                 game.settings.get(MODULENAME, "autoRollDamageForSpellWhenNotAnAttack") === "allSpells" &&
-                (rollForNonSpellAttack ||
+                (rollForNonAttackSpell ||
                     rollForNonAttackSaveSpell ||
                     rollForNonAttackNonSaveSpell ||
                     rollForAttackSpell);


### PR DESCRIPTION
At least, it would try to, but fail since the spell damage roll doesn't work on a strike.  But it prevented auto-roll damage for strikes from working.

* **Please check if the PR fulfills these requirements**

- [x ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
auto roll for all spells breaks autoroll for strikes

* **What is the new behavior (if this is a feature change)?**
doesn't break strikes

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
no

* **Other information**:
