### PR TITLE
feat: Message flag to skip damage rolls and expose autoRollDamage

### DIFF
--- a/src/module/feature/damageHandler/index.ts
+++ b/src/module/feature/damageHandler/index.ts
@@ -17,7 +17,14 @@ export async function autoRollDamage(message: ChatMessagePF2e) {
         autoRollDamageForSpellWhenNotAnAttack: game.settings.get(MODULENAME, "autoRollDamageForSpellWhenNotAnAttack"),
     };
 
+    const shouldAutoRollDamage =
+        settings.autoRollDamageAllow &&
+        (settings.autoRollDamageForStrike ||
+            settings.autoRollDamageForSpellAttack ||
+            settings.autoRollDamageForSpellWhenNotAnAttack !== "no");
+
     if (
+        shouldAutoRollDamage &&
         shouldIHandleThisMessage(
             message,
             ["all", "players"].includes(settings.autoRollDamageAllow),

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -110,20 +110,8 @@ export function createChatMessageHook(message: ChatMessagePF2e) {
     const isDamage = isDamageRoll || isDamageTaken(message);
 
     if (!isDamage) {
-        // Check if we need to auto roll damage
-        const autoRollDamageAllow = game.settings.get(MODULENAME, "autoRollDamageAllow");
-        const autoRollDamageForStrike = game.settings.get(MODULENAME, "autoRollDamageForStrike");
-        const autoRollDamageForSpellAttack = game.settings.get(MODULENAME, "autoRollDamageForSpellAttack");
-        const autoRollDamageForSpellWhenNotAnAttack = game.settings.get(
-            MODULENAME,
-            "autoRollDamageForSpellWhenNotAnAttack",
-        );
-
-        const shouldAutoRollDamage =
-            autoRollDamageAllow &&
-            (autoRollDamageForStrike || autoRollDamageForSpellAttack || autoRollDamageForSpellWhenNotAnAttack !== "no");
-
-        if (shouldAutoRollDamage) {
+        const skipAutoRoll = message.getFlag(MODULENAME, "noAutoDamageRoll");
+        if (!skipAutoRoll) {
             autoRollDamage(message).then();
         }
 

--- a/src/module/xdy-pf2e-workbench.ts
+++ b/src/module/xdy-pf2e-workbench.ts
@@ -47,7 +47,7 @@ import {
 } from "./feature/heroPointHandler/index.js";
 import { moveSelectedAheadOfCurrent } from "./feature/initiativeHandler/index.js";
 import { doMystificationFromToken } from "./feature/tokenMystificationHandler/index.js";
-import { noOrSuccessfulFlatcheck } from "./feature/damageHandler/index.js";
+import { autoRollDamage, noOrSuccessfulFlatcheck } from "./feature/damageHandler/index.js";
 import { registerWorkbenchSettings } from "./settings/index.js";
 import { SettingsMenuPF2eWorkbench } from "./settings/menu.js";
 import { toggleMenuSettings } from "./feature/settingsHandler/index.js";
@@ -410,6 +410,7 @@ Hooks.once("ready", () => {
         mystifyNpcItems: mystifyNpcItems, // await game.PF2eWorkbench.mystifyNpcItems() OR await game.PF2eWorkbench.mystifyNpcItems(items, minimumRarity, usingPartyLevel, minimumLevel, multiplier)
         getAllFromAllowedPacks: getAllFromAllowedPacks, // await game.PF2eWorkbench.getAllFromAllowedPacks({ type, fields, filter, strictSourcing, fetch})
         npcScaler: npcScaler, // await game.PF2eWorkbench.npcScaler()
+        autoRollDamage: autoRollDamage, // await await game.PF2eWorkbench.autoRollDamage(message)
     };
 
     if (game.modules.get("pf2e-sheet-skill-actions")?.active) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds a flag to messages that lets other modules turn off the auto damage roll for that message.
The flag is on the message, so it can be set when the message is created (for macros) or in the preCreate/create message hooks.
Also exposes the autoRollDamage function so it can be called on a message after it has been created.
