### PR TITLE
fix french for the saving throw on the hidden spell display

### DIFF
--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -7,7 +7,7 @@
       "nav-labels": {
         "strike": "Frappes",
         "damage": "Dégâts",
-        "ac": "Classe d’Armure",
+        "ac": "Classe d'Armure",
         "save": "Jet de Sauvegarde",
         "hp": "Points de Vie",
         "spell": "Sort",
@@ -228,7 +228,7 @@
         "addOneForCharacters": "Ajouter 1, pour les personnages + familiers",
         "addWoundedLevel": "Ajouter 1 + niveau Blessé, pour tous",
         "addWoundedLevelForCharacters": "Ajouter 1 + niveau Blessé, pour les personnages + familiers",
-        "deliberateDeathMessage": "{name} peut <b>avant d'être mourant en jeu</b> du fait d'une attaque ou d'une capacité d'une autre créature, si cette créature est à portée d'attaque au corps-à-corps, porter une Frappe au corps-à-corps contre la créature déclencheuse.<br>Supprimer l'effet 'Mort délivéré utilisée' si il ne peut pas être actuellement utilisé.",
+        "deliberateDeathMessage": "{name} peut <b>avant d'être mourant en jeu</b> du fait d'une attaque ou d'une capacité d'une autre créature, si cette créature est à portée d'attaque au corps-à-corps, porter une Frappe au corps-à-corps contre la créature déclencheuse.<br>Supprimer l'effet 'Mort délibérée utilisée' si il ne peut pas être actuellement utilisé.",
         "hint": "Réglage pour automatiquement augmenter mourant à 0 PV.",
         "name": "Automatiquement augmenter Mourant à 0 PV.",
         "no": "Non",
@@ -340,7 +340,7 @@
       "handleDyingRecoveryRoll": {
         "hint": "Paramètre du client permettant de traiter automatiquement les résultats des tests de récupération après avoir cliqué sur le bouton de récupération.",
         "name": "Automatiser le traitement des tests de récupération après avoir cliqué sur le bouton récupération.",
-        "handled": "Jet de récupération {roll} {outcome} géré automatiquement. {défeated}.",
+        "handled": "Jet de récupération {roll} {outcome} géré automatiquement. {defeated}.",
         "defeated": "{name} a été vaincu"
       },
       "playerFeatsPrerequisiteHint": {
@@ -400,7 +400,7 @@
         "name": "Poste un message public pour dire qu'un sort a été lancé.",
         "basic": "Basique",
         "noButtonSavePart": "<br><b>jet de {dataSave} {basic}</b>",
-        "savePart": "<br>Le jet de sauvegarde du sort inconnu est : @Check[type :{dataSave}|dc :{dataDC}|traits :{traits}{basic}]",
+        "savePart": "<br>Le jet de sauvegarde du sort inconnu est : @Check[type:{dataSave}|dc:{dataDC}|traits:{traits}{basic}]",
         "secondPartNoRk": ".<br>Vous pouvez essayer d'utiliser @UUID[Compendium.pf2e.feats-srd.MjQyTcV8Jiv1Jtln] ou @UUID[Compendium.pf2e.feats-srd.2rSyTfPgAmNAo01r] pour le reconnaître. Ou, lors de votre tour, dépensez une action pour tenter de l'identifier (demandez à votre MJ les détails).",
         "secondPartRK": ".<br>Vous pouvez essayer d'utiliser soit @UUID[Compendium.pf2e.feats-srd.MjQyTcV8Jiv1Jtln], soit @UUID[Compendium.pf2e.feats-srd.2rSyTfPgAmNAo01r] pour le reconnaître. Ou, à votre tour, dépensez une action pour tenter de l'identifier avec un test de @Check[type:{skill}|dc:{dcRK}|traits:secret,action:recall-knowledge] @UUID[Compendium.pf2e.actionspf2e.Item.1OagaWtBpVXExToo] (ou en passant 10 minutes avec un test de @Check[type:{skill}|dc:{dcRK}|traits:secret,action:identify-magic] @UUID[Compendium.pf2e.actionspf2e.Item.eReSHVEPCsdkSL4G] )",
         "spell": "Sort",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -404,7 +404,7 @@
         "secondPartNoRk": ".<br>Vous pouvez essayer d'utiliser @UUID[Compendium.pf2e.feats-srd.MjQyTcV8Jiv1Jtln] ou @UUID[Compendium.pf2e.feats-srd.2rSyTfPgAmNAo01r] pour le reconnaître. Ou, lors de votre tour, dépensez une action pour tenter de l'identifier (demandez à votre MJ les détails).",
         "secondPartRK": ".<br>Vous pouvez essayer d'utiliser soit @UUID[Compendium.pf2e.feats-srd.MjQyTcV8Jiv1Jtln], soit @UUID[Compendium.pf2e.feats-srd.2rSyTfPgAmNAo01r] pour le reconnaître. Ou, à votre tour, dépensez une action pour tenter de l'identifier avec un test de @Check[type:{skill}|dc:{dcRK}|traits:secret,action:recall-knowledge] @UUID[Compendium.pf2e.actionspf2e.Item.1OagaWtBpVXExToo] (ou en passant 10 minutes avec un test de @Check[type:{skill}|dc:{dcRK}|traits:secret,action:identify-magic] @UUID[Compendium.pf2e.actionspf2e.Item.eReSHVEPCsdkSL4G] )",
         "spell": "Sort",
-        "they": "Ils",
+        "they": "On",
         "knownBy": "<div><p><b>Connu par : </b>{spellHavers}</p></div><hr class=\"item-block-divider\">"
       },
       "castPrivateSpellWithPublicMessageShowToGM": {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix. Saving throw was broken in french for hidden spells.

* **What is the current behavior?** (You can also link to an open issue here)
it shows `@Check[type :will|dc :27|traits :concentrate,incapacitation,manipulate,mental,sleep]`

* **What is the new behavior (if this is a feature change)?**
it shows `@Check[type:will|dc:27|traits:concentrate,incapacitation,manipulate,mental,sleep]` (spaces removed inside the check)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
no

* **Other information**:
