### PR TITLE
feat: Use NPC skill proficiency for BAM actions

### DIFF
--- a/static/templates/macros/bam/actionButton.hbs
+++ b/static/templates/macros/bam/actionButton.hbs
@@ -7,19 +7,19 @@
 {{#if action.showMAP}}
     <div class="bam-map-wrapper">
         <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="0" 
-                data-rank="{{skill.rank}}" data-tooltip="{{> actionTooltip}}">
+                data-rank="{{rank}}" data-tooltip="{{> actionTooltip}}">
             <img src="{{coalesce action.icon "systems/pf2e/icons/actions/craft/unknown-item.webp"}}" height="24" width="24" alt="{{> actionName}}"/>
             {{> actionName}}
         </button>
-        <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="{{action.MAP.[0]}}" data-rank="{{skill.rank}}">
+        <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="{{action.MAP.[0]}}" data-rank="{{rank}}">
             {{action.MAP.[0]}}
         </button>
-        <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="{{action.MAP.[1]}}" data-rank="{{skill.rank}}">
+        <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-map="{{action.MAP.[1]}}" data-rank="{{rank}}">
             {{action.MAP.[1]}}
         </button>
     </div>
 {{else}}
-    <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-rank="{{skill.rank}}"
+    <button class="bam-action-btn{{#if best}} glow{{/if}}" data-action="{{idx}}" data-rank="{{rank}}"
             data-tooltip="{{> actionTooltip}}">
         <img src="{{coalesce action.icon "systems/pf2e/icons/actions/craft/unknown-item.webp"}}" height="24" alt="{{name}}"/>
         {{> actionName}}


### PR DESCRIPTION
NPCs were considered untrained in all skills for action color, but as trained in all skills when determining if they can use a trained skill action.

Use the system's boolean skill.proficient value for NPC skills as if it was untrained vs trained rank.  Trained actions will be skipped (subject to the global show all actions setting) for non-proficient skills and the buttons will be colored as-if untrained or trained.

Just pass the skill rank to the hbs template, not the whole skill, since rank was the only thing used.  We don't want to modify the skill object since that's owned by the actor.

Clean up the action filter somewhat too.

* **Please check if the PR fulfills these requirements**

- [X ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
BAM doesn't use NPC skill proficiency.

* **What is the new behavior (if this is a feature change)?**
BAM considers NPC skills as either trained or untrained.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No.

* **Other information**:
