### PR TITLE
fix: Don't drop items multiple times on unconscious

### DIFF
--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -249,8 +249,8 @@ function handleVariantHeroPointRules(message: ChatMessagePF2e, jq: JQuery) {
     }
 }
 
-function dropHeldItemsOnBecomingUnconscious(actor) {
-    const items = <PhysicalItemPF2e[]>actor.items?.filter((i) => i.isHeld);
+function dropHeldItemsOnBecomingUnconscious(actor: CreaturePF2e) {
+    const items = actor.inventory.filter((i) => i.isHeld);
     if (items && items.length > 0) {
         for (const item of items) {
             if (item.traits.has("free-hand") || item.type === "shield" || item.traits.has("attached-to-shield")) {
@@ -267,7 +267,7 @@ function dropHeldItemsOnBecomingUnconscious(actor) {
         ChatMessage.create({
             flavor: message,
             speaker: ChatMessage.getSpeaker({ actor }),
-        }).then();
+        });
     }
 }
 
@@ -301,12 +301,12 @@ function sheatheHeldItemsAfterEncounter(encounter: EncounterPF2e) {
     });
 }
 
-export async function createItemHook(item: ItemPF2e, _options: any, _id: any) {
+export async function preCreateItemHook(item: ItemPF2e, _data: object, _options: any, _id: string) {
     if (
+        item.type === "condition" &&
+        item.slug === "unconscious" &&
         item.actor?.isOfType(CHARACTER_TYPE) &&
-        item.actor.hasCondition("unconscious") &&
-        game.settings.get(MODULENAME, "dropHeldItemsOnBecomingUnconscious") &&
-        shouldIHandleThis(item.actor)
+        game.settings.get(MODULENAME, "dropHeldItemsOnBecomingUnconscious")
     ) {
         dropHeldItemsOnBecomingUnconscious(item.actor);
     }

--- a/src/module/xdy-pf2e-workbench.ts
+++ b/src/module/xdy-pf2e-workbench.ts
@@ -20,7 +20,7 @@ import { basicActionMacros, registerBasicActionMacrosHandlebarsTemplates } from 
 import { buildNpcSpellbookJournal } from "./feature/macros/buildNpcSpellbookJournal.js";
 import {
     createChatMessageHook,
-    createItemHook,
+    preCreateItemHook,
     createTokenHook,
     deleteCombatHook,
     deleteItemHook,
@@ -153,11 +153,7 @@ export function updateHooks(cleanSlate = false) {
         renderChatMessageHook,
     );
 
-    handle(
-        "createItem",
-        game.settings.get(MODULENAME, "dropHeldItemsOnBecomingUnconscious"),
-        fu.debounce(createItemHook, 10),
-    );
+    handle("preCreateItem", game.settings.get(MODULENAME, "dropHeldItemsOnBecomingUnconscious"), preCreateItemHook);
 
     handle("updateItem", false, updateItemHook);
 


### PR DESCRIPTION
The drop items on unconscious hook was running on itemCreate.  This means it runs for every item (so 4 times, for unconscious, prone, blinded, and off-guard conditions) for every user.

This means that multiple users on mutltiple conditions might decide to drop items.  The debounce makes that less likely, but it's still possible.

There's an assumption that once all held items are dropped, nothing will happen if dropHeldItemsOnBecomingUnconscious() is called again because nothing will be held anymore.  But the database update is async and not awaited.  It's possible the function will be called multiple times before the database update propagates and the same items will be dropped multiple times.

Switch the hook to preCreateItem, which is only called by the single user who is making the actor unconscious.  So the whole multiple users acting async problem goes away.  Trigger only when the unconscious condition is created.  This avoid re-triggering on blinded, prone, etc.

Also use actor.inventory, which only has physical items, instead of actor.items.  The non-physical items don't even have the isHeld property so they'd never match.  And type annotate the actor argument, since typescript doesn't know what actor is otherwise.  Now ts knows the results of filtering actor.inventory must all be physical items.

* **Please check if the PR fulfills these requirements**

- [x ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

* **What is the current behavior?** (You can also link to an open issue here)
Sometimes drop on unconscious multiple times.

* **What is the new behavior (if this is a feature change)?**
Just drop once.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No.

* **Other information**:
