### PR TITLE
fix: add "renderGamePause" hook that mirrors use of "renderPause" for…

### DIFF
--- a/src/module/xdy-pf2e-workbench.ts
+++ b/src/module/xdy-pf2e-workbench.ts
@@ -219,6 +219,11 @@ export function updateHooks(cleanSlate = false) {
     changePauseText();
 }
 
+// "renderGamePause" is the AppV2 equivalent to "renderPause", used in Foundry v13+
+Hooks.on("renderGamePause", (_app, _html, _options) => {
+    changePauseText();
+});
+
 Hooks.on("renderPause", (_app, _html, _options) => {
     changePauseText();
 });


### PR DESCRIPTION
Add use of `"renderGamePause"` hook (used by the AppV2 pause overlay) that mirrors use of `"renderPause"` for compatibility with v13.

Addresses #1612

* **Please check if the PR fulfills these requirements**

- [*] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [*] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add use of `"renderGamePause"` hook that mirrors use of `"renderPause"` for compatibility with v13.

* **What is the current behavior?** (You can also link to an open issue here)

Only `"renderPause"` is used, leading to pause overlay settings not being used on triggering pause on v13.

* **What is the new behavior (if this is a feature change)?**

`"renderGamePause"` is also used.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

Not afaik. But to be honest, I did not test with v12. Registering on a non-existing hook seems to not break anything, so should be fine?

* **Other information**:
Have a nice day :)