### PR TITLE
fix: NPC scaler was breaking compendium list right click

### DIFF
--- a/src/module/feature/cr-scaler/NPCScalerSetup.ts
+++ b/src/module/feature/cr-scaler/NPCScalerSetup.ts
@@ -19,7 +19,7 @@ import { ActorDirectoryPF2e } from "foundry-pf2e";
 import { ContextMenuEntry } from "foundry/client/applications/ux/context-menu.mts";
 
 function condition(li: HTMLElement): boolean {
-    return game.actors.get(li.dataset.entryId, { strict: true })?.isOfType("npc");
+    return li.dataset.entryId !== undefined && (game.actors.get(li.dataset.entryId)?.isOfType("npc") ?? false);
 }
 
 function callback(li: HTMLElement) {


### PR DESCRIPTION
The context menu also triggers on compendium, not just local actors directory. It breaks since none of the items in compendiums will be in game.actors and using strict causes an error trying to get them.

* **Please check if the PR fulfills these requirements**

- [X] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)


* **Other information**:
