### PR TITLE
Set hookOptions to keep the higher roll and leave it at that

### DIFF
--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -431,22 +431,7 @@ export function pf2eRerollHook(
         newRoll.options.heroicReroll = true;
     } else if (game.settings.get(MODULENAME, "heroPointRules") === "useHighestHeroPointRoll") {
         // Handle useHighestHeroPointRoll setting
-        const oldDie = oldRoll.dice.find(
-            (d) => d instanceof foundry.dice.terms.Die && d.number === 1 && d.faces === 20,
-        );
-        const oldResult = oldDie?.results.find((r) => r.active)?.result ?? 0;
-        const newResult = die?.results.find((r) => r.active)?.result ?? 0;
-
-        if (oldResult > newResult) {
-            // Replace the new roll's d20 result with the old roll's result
-            if (die && die.results.length > 0) {
-                die.results[0].result = oldResult;
-                // @ts-expect-error It's protected. Meh.
-                newRoll._total = newRoll.options.keeleyAdd10 ? oldRoll._total + 10 : oldRoll._total;
-                newRoll.options.useHighestRoll = true;
-            }
-        }
-        return;
+        hookOptions.keep = "higher";
     }
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes `useHighestHeroPointRoll`

* **What is the current behavior?** (You can also link to an open issue here)
Current behavior is to modify the new roll to match the old roll

* **What is the new behavior (if this is a feature change)?**
Sets `hookOptions.keep` to `higher` and leave it up to PF2e

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No

* **Other information**:
The check for `newRoll.options.keeleyAdd10` is completely pointless as it will never occur since the `heroPointRules` setting can't both be `keeleysHeroPointRule` and `useHighestHeroPointRoll`