### PR TITLE
fix: Frighten reduction works with feat Calm And Centered

### DIFF
--- a/src/module/feature/conditionHandler/index.ts
+++ b/src/module/feature/conditionHandler/index.ts
@@ -12,9 +12,13 @@ export async function reduceFrightened(combatant: CombatantPF2e, userId: string)
         const minimumFrightened = getModuleFlag(actor, "condition.frightened.min", 0);
         const frightened = actor.getCondition("frightened");
         const currentFrightened = frightened?.value ?? 0;
+        const doubleFrightenReductionSlugs: string[] = [
+            "dwarven-doughtiness",
+            "calm-and-centered"
+        ]
 
         if (frightened && currentFrightened > 0 && !frightened.isLocked) {
-            const reduceBy = actorHasItemBySlug(actor, "dwarven-doughtiness") ? 2 : 1;
+            const reduceBy = doubleFrightenReductionSlugs.some((slug) => actorHasItemBySlug(actor, slug)) ? 2 : 1;
 
             for (let i = 0; i < reduceBy && currentFrightened - i > minimumFrightened; i++) {
                 await actor.decreaseCondition("frightened");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so
  follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines.)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Frighten reduction works with the calm and centered feat reducing it by 2 at the end of the users turn

* **What is the current behavior?** (You can also link to an open issue here)
Frighten gets reduced by 1 if the actor has the calm and featured feat added

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)


* **Other information**:
https://2e.aonprd.com/Feats.aspx?ID=8190